### PR TITLE
change config directory on linux to $HOME/.config/livesplitone/

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1777,7 +1777,7 @@ checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 [[package]]
 name = "livesplit-auto-splitting"
 version = "0.1.0"
-source = "git+https://github.com/LiveSplit/livesplit-core#f803c68f87783ecbe733f89e8745f4778f4e0ab9"
+source = "git+https://github.com/AlexKnauth/livesplit-core?branch=legacy-xml-hack#d83403b864697700c901b8251a9da683d4032f49"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1799,7 +1799,7 @@ dependencies = [
 [[package]]
 name = "livesplit-core"
 version = "0.13.0"
-source = "git+https://github.com/LiveSplit/livesplit-core#f803c68f87783ecbe733f89e8745f4778f4e0ab9"
+source = "git+https://github.com/AlexKnauth/livesplit-core?branch=legacy-xml-hack#d83403b864697700c901b8251a9da683d4032f49"
 dependencies = [
  "base64-simd",
  "bytemuck",
@@ -1833,7 +1833,7 @@ dependencies = [
 [[package]]
 name = "livesplit-hotkey"
 version = "0.7.0"
-source = "git+https://github.com/LiveSplit/livesplit-core#f803c68f87783ecbe733f89e8745f4778f4e0ab9"
+source = "git+https://github.com/AlexKnauth/livesplit-core?branch=legacy-xml-hack#d83403b864697700c901b8251a9da683d4032f49"
 dependencies = [
  "bitflags 2.4.0",
  "cfg-if",
@@ -1871,7 +1871,7 @@ dependencies = [
 [[package]]
 name = "livesplit-title-abbreviations"
 version = "0.3.0"
-source = "git+https://github.com/LiveSplit/livesplit-core#f803c68f87783ecbe733f89e8745f4778f4e0ab9"
+source = "git+https://github.com/AlexKnauth/livesplit-core?branch=legacy-xml-hack#d83403b864697700c901b8251a9da683d4032f49"
 dependencies = [
  "unicase",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1777,7 +1777,7 @@ checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 [[package]]
 name = "livesplit-auto-splitting"
 version = "0.1.0"
-source = "git+https://github.com/LiveSplit/livesplit-core#d8ba361d97e975c1ba5302e77c9833dc95cd9855"
+source = "git+https://github.com/AlexKnauth/livesplit-core?branch=legacy-xml-hack#e61a5e6b15c016c978f418b639301501b8af48e4"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1799,7 +1799,7 @@ dependencies = [
 [[package]]
 name = "livesplit-core"
 version = "0.13.0"
-source = "git+https://github.com/LiveSplit/livesplit-core#d8ba361d97e975c1ba5302e77c9833dc95cd9855"
+source = "git+https://github.com/AlexKnauth/livesplit-core?branch=legacy-xml-hack#e61a5e6b15c016c978f418b639301501b8af48e4"
 dependencies = [
  "base64-simd",
  "bytemuck",
@@ -1833,7 +1833,7 @@ dependencies = [
 [[package]]
 name = "livesplit-hotkey"
 version = "0.7.0"
-source = "git+https://github.com/LiveSplit/livesplit-core#d8ba361d97e975c1ba5302e77c9833dc95cd9855"
+source = "git+https://github.com/AlexKnauth/livesplit-core?branch=legacy-xml-hack#e61a5e6b15c016c978f418b639301501b8af48e4"
 dependencies = [
  "bitflags 2.4.0",
  "cfg-if",
@@ -1871,7 +1871,7 @@ dependencies = [
 [[package]]
 name = "livesplit-title-abbreviations"
 version = "0.3.0"
-source = "git+https://github.com/LiveSplit/livesplit-core#d8ba361d97e975c1ba5302e77c9833dc95cd9855"
+source = "git+https://github.com/AlexKnauth/livesplit-core?branch=legacy-xml-hack#e61a5e6b15c016c978f418b639301501b8af48e4"
 dependencies = [
  "unicase",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 
 [dependencies]
 druid = { git = "https://github.com/CryZe/druid", branch = "changes-for-livesplit-one" }
-livesplit-core = { git = "https://github.com/LiveSplit/livesplit-core", features = ["font-loading", "software-rendering"] }
+livesplit-core = { git = "https://github.com/AlexKnauth/livesplit-core", branch = "legacy-xml-hack", features = ["font-loading", "software-rendering"] }
 image = "0.24.2"
 log = { version = "0.4.6", features = ["serde"] }
 serde = { version = "1.0.85", features = ["derive", "rc"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -125,7 +125,7 @@ impl Default for Window {
 
 static CONFIG_PATH: Lazy<PathBuf> = Lazy::new(|| {
     ProjectDirs::from("org", "LiveSplit", "LiveSplit One")
-        .map(|dirs| dirs.data_local_dir().join("config.yml"))
+        .map(|dirs| dirs.config_local_dir().join("config.yml"))
         .unwrap_or_default()
 });
 


### PR DESCRIPTION
The most commonly used config directory on linux is $HOME/.config/projectname, this project uses $HOME/.local/share/projectname, I don't think this makes sense at all.

To change this I used config_local_dir instead of data_local_dir from the directories crate.

This will NOT change the Windows or Mac directories.