### PR TITLE
Update autosplitter settings when changing splits

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -251,6 +251,7 @@ impl Config {
         &mut self,
         timer: &mut Timer,
         layout_data: &mut LayoutData,
+        auto_splitter: &livesplit_core::auto_splitting::Runtime,
         path: PathBuf,
     ) -> Result<()> {
         let file = fs::read(&path).context("Failed reading the file.")?;
@@ -264,6 +265,9 @@ impl Config {
         self.splits.add_to_history(timer.run());
 
         self.save_config();
+
+        #[cfg(feature = "auto-splitting")]
+        self.maybe_load_auto_splitter(auto_splitter, timer.clone().into_shared());
 
         if let Some(linked_layout) = timer.run().linked_layout() {
             match linked_layout {

--- a/src/timer_form.rs
+++ b/src/timer_form.rs
@@ -355,6 +355,7 @@ impl<T: Widget<MainState>> Widget<MainState> for WithMenu<T> {
                     let result = data.config.borrow_mut().open_splits(
                         &mut data.timer.write().unwrap(),
                         &mut data.layout_data.borrow_mut(),
+                        &data.auto_splitter,
                         file_info.path().to_path_buf(),
                     );
                     or_show_error(result);


### PR DESCRIPTION
To fix #3.

- [x] Test it by switching between multiple splits files without restarting `livesplit-one-druid`. (Tested on Windows, failed to test on Mac)