### PR TITLE
Just directly construct the HotkeySystem from the config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,7 @@ use druid::WindowDesc;
 #[cfg(feature = "auto-splitting")]
 use livesplit_core::event::TimerAutoSplitterSettings;
 use livesplit_core::{
+    event,
     layout::{self, Layout, LayoutSettings},
     run::{
         parser::{composite, TimerKind},
@@ -223,9 +224,9 @@ impl Config {
             .unwrap_or_else(Layout::default_layout)
     }
 
-    // TODO: Just directly construct the HotkeySystem from the config.
-    pub fn configure_hotkeys(&self, hotkeys: &mut HotkeySystem<SharedTimer>) {
-        hotkeys.set_config(self.hotkeys).ok();
+    // Just directly construct the HotkeySystem from the config.
+    pub fn configure_hotkeys<E: event::Sink + Clone + Send + 'static>(&self, event_sink: E) -> HotkeySystem<E> {
+        HotkeySystem::with_config(event_sink, self.hotkeys).unwrap()
     }
 
     pub fn configure_timer(&self, timer: &mut Timer) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -225,7 +225,10 @@ impl Config {
     }
 
     // Just directly construct the HotkeySystem from the config.
-    pub fn configure_hotkeys<E: event::Sink + Clone + Send + 'static>(&self, event_sink: E) -> HotkeySystem<E> {
+    pub fn configure_hotkeys<E: event::Sink + Clone + Send + 'static>(
+        &self,
+        event_sink: E,
+    ) -> HotkeySystem<E> {
         HotkeySystem::with_config(event_sink, self.hotkeys).unwrap()
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,8 +97,7 @@ impl MainState {
         let layout = config.parse_layout_or_default(&timer);
 
         let timer = timer.into_shared();
-        let mut hotkey_system = HotkeySystem::new(timer.clone()).unwrap();
-        config.configure_hotkeys(&mut hotkey_system);
+        let hotkey_system = config.configure_hotkeys(timer.clone());
         *HOTKEY_SYSTEM.write().unwrap() = Some(hotkey_system);
 
         #[cfg(feature = "auto-splitting")]


### PR DESCRIPTION
Fixes #16 by constructing the `HotkeySystem` from the config, instead of initializing with default keys and then setting them to the new config one at a time.