### PR TITLE
new_scaled_dims vs new_dims

### DIFF
--- a/src/software_renderer.rs
+++ b/src/software_renderer.rs
@@ -10,7 +10,7 @@ pub fn render_scene(
     renderer: &mut Renderer,
     state: &LayoutState,
     image_cache: &ImageCache,
-) -> Option<[f32; 2]> {
+) -> Option<(f64, f64)> {
     let size = paint_ctx.size();
     let scale = paint_ctx.scale();
     let scaled_width = size.width * scale.x();
@@ -19,7 +19,8 @@ pub fn render_scene(
     let (width, height) = (scaled_width as u32, scaled_height as u32);
     let dimensions = renderer.image().dimensions();
 
-    let new_dims = renderer.render(state, image_cache, [width, height]);
+    let new_scaled_dims = renderer.render(state, image_cache, [width, height]);
+    let new_dims = new_scaled_dims.map(|[w, h]| scale.px_to_dp_xy(w, h));
 
     let bottom_image = if bottom_image.is_none() || dimensions != (width, height) {
         bottom_image.insert(

--- a/src/timer_form.rs
+++ b/src/timer_form.rs
@@ -763,7 +763,7 @@ impl<T: Widget<MainState>> Widget<MainState> for WithMenu<T> {
         //     &data.image_cache.borrow(),
         // );
 
-        if let Some([new_width, new_height]) = software_renderer::render_scene(
+        if let Some((new_width, new_height)) = software_renderer::render_scene(
             ctx,
             &mut self.bottom_image,
             &mut self.renderer,
@@ -771,7 +771,7 @@ impl<T: Widget<MainState>> Widget<MainState> for WithMenu<T> {
             &data.image_cache.borrow(),
         ) {
             ctx.window()
-                .set_size(Size::new(new_width as _, new_height as _));
+                .set_size(Size::new(new_width, new_height));
         }
         data.image_cache.borrow_mut().collect();
     }


### PR DESCRIPTION
Fixes the version of https://github.com/CryZe/livesplit-one-druid/issues/3 for this fork, by using `scale.px_to_dp_xy` to convert back from a post-scale size in pixels to pre-scale size in display points.