### PR TITLE
livesplit-core: split-index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1963,7 +1963,7 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 [[package]]
 name = "livesplit-auto-splitting"
 version = "0.1.0"
-source = "git+https://github.com/AlexKnauth/livesplit-core?branch=legacy_raw_xml-3#4105eaeadb7816d901a56a56af409150dc6fbfdc"
+source = "git+https://github.com/AlexKnauth/livesplit-core?branch=legacy_raw_xml#6a1259af0e8231d8e250ae1ac8fadc1639b036a2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1985,7 +1985,7 @@ dependencies = [
 [[package]]
 name = "livesplit-core"
 version = "0.13.0"
-source = "git+https://github.com/AlexKnauth/livesplit-core?branch=legacy_raw_xml-3#4105eaeadb7816d901a56a56af409150dc6fbfdc"
+source = "git+https://github.com/AlexKnauth/livesplit-core?branch=legacy_raw_xml#6a1259af0e8231d8e250ae1ac8fadc1639b036a2"
 dependencies = [
  "base64-simd",
  "bytemuck",
@@ -2020,7 +2020,7 @@ dependencies = [
 [[package]]
 name = "livesplit-hotkey"
 version = "0.7.0"
-source = "git+https://github.com/AlexKnauth/livesplit-core?branch=legacy_raw_xml-3#4105eaeadb7816d901a56a56af409150dc6fbfdc"
+source = "git+https://github.com/AlexKnauth/livesplit-core?branch=legacy_raw_xml#6a1259af0e8231d8e250ae1ac8fadc1639b036a2"
 dependencies = [
  "bitflags 2.5.0",
  "cfg-if",
@@ -2059,7 +2059,7 @@ dependencies = [
 [[package]]
 name = "livesplit-title-abbreviations"
 version = "0.3.0"
-source = "git+https://github.com/AlexKnauth/livesplit-core?branch=legacy_raw_xml-3#4105eaeadb7816d901a56a56af409150dc6fbfdc"
+source = "git+https://github.com/AlexKnauth/livesplit-core?branch=legacy_raw_xml#6a1259af0e8231d8e250ae1ac8fadc1639b036a2"
 
 [[package]]
 name = "lock_api"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ build = "build.rs"
 
 [dependencies]
 druid = { git = "https://github.com/AlexKnauth/druid", branch = "mouse_pass_through" }
-livesplit-core = { git = "https://github.com/AlexKnauth/livesplit-core", branch = "legacy_raw_xml-3", features = ["font-loading", "software-rendering"] }
+livesplit-core = { git = "https://github.com/AlexKnauth/livesplit-core", branch = "legacy_raw_xml", features = ["font-loading", "software-rendering"] }
 image = "0.25.0"
 log = { version = "0.4.6", features = ["serde"] }
 serde = { version = "1.0.85", features = ["derive", "rc"] }


### PR DESCRIPTION
Adds `timer_current_split_index` to the Auto-Splitting Runtime.