### PR TITLE
CLI arguments for splits, layout and autosplitter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,7 +289,7 @@ dependencies = [
  "bitflags 2.5.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -506,6 +555,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+
+[[package]]
 name = "cocoa"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,6 +645,12 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "console_error_panic_hook"
@@ -1792,6 +1887,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2041,6 +2142,7 @@ dependencies = [
  "anyhow",
  "backtrace",
  "chrono",
+ "clap",
  "directories",
  "druid",
  "embed-resource",
@@ -3245,6 +3347,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3737,6 +3845,12 @@ name = "utf16_lit"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14706d2a800ee8ff38c1d3edb873cd616971ea59eb7c0d046bb44ef59b06a1ae"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "v_frame"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ once_cell = "1.16.0"
 native-dialog = "0.7.0"
 anyhow = "1.0.68"
 fontdb = "0.15.0"
+clap = { version = "4.5.20", features = ["derive"] }
 
 [build-dependencies]
 embed-resource = "2.4"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,6 +5,14 @@ use clap::Parser;
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
 pub struct Cli {
-    /// Split file to open. If not given, opens the last split file used
-    pub split_file: Option<PathBuf>,
+    /// Split file to open. If not given, takes it from config file (the last one used)
+    pub splits: Option<PathBuf>,
+
+    /// Autosplitter file to open. If not given, takes it from config file (the last one used)
+    #[arg(short, long, value_name = "FILE")]
+    pub autosplitter: Option<PathBuf>,
+
+    /// Layout file to open. If not given, takes it from config file (the last one used)
+    #[arg(short, long, value_name = "FILE")]
+    pub layout: Option<PathBuf>,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,10 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+
+#[derive(Parser)]
+#[command(version, about, long_about = None)]
+pub struct Cli {
+    /// Split file to open. If not given, opens the last split file used
+    pub split_file: Option<PathBuf>,
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -131,23 +131,22 @@ static CONFIG_PATH: Lazy<PathBuf> = Lazy::new(|| {
 });
 
 impl Config {
-    pub fn load(split_file: Option<String>) -> Self {
+    pub fn load(split_file: Option<PathBuf>) -> Self {
         let cfg = Self::parse().unwrap_or_default();
         cfg.load_path_splits(split_file)
     }
 
     /// Replace the current splits file with the given path during load, before the window is initialized
     /// If the file path is invalid it keeps the split file specified in the config
-    fn load_path_splits(mut self, split_file: Option<String>) -> Self {
+    fn load_path_splits(mut self, split_file: Option<PathBuf>) -> Self {
         if split_file.is_none() { return self; };
         let split_file = split_file.unwrap();
-        let path = PathBuf::from(split_file);
         // This reads the file twice, once now and again below when splits are opened
-        let maybe_run = Config::parse_run_from_path(&path);
+        let maybe_run = Config::parse_run_from_path(&split_file);
         if maybe_run.is_none() { return self; };
         let (run, _) = maybe_run.unwrap();
         self.splits.add_to_history(&run);
-        self.splits.current = Some(path);
+        self.splits.current = Some(split_file);
         self
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -131,8 +131,24 @@ static CONFIG_PATH: Lazy<PathBuf> = Lazy::new(|| {
 });
 
 impl Config {
-    pub fn load() -> Self {
-        Self::parse().unwrap_or_default()
+    pub fn load(split_file: Option<String>) -> Self {
+        let cfg = Self::parse().unwrap_or_default();
+        cfg.load_path_splits(split_file)
+    }
+
+    /// Replace the current splits file with the given path during load, before the window is initialized
+    /// If the file path is invalid it keeps the split file specified in the config
+    fn load_path_splits(mut self, split_file: Option<String>) -> Self {
+        if split_file.is_none() { return self; };
+        let split_file = split_file.unwrap();
+        let path = PathBuf::from(split_file);
+        // This reads the file twice, once now and again below when splits are opened
+        let maybe_run = Config::parse_run_from_path(&path);
+        if maybe_run.is_none() { return self; };
+        let (run, _) = maybe_run.unwrap();
+        self.splits.add_to_history(&run);
+        self.splits.current = Some(path);
+        self
     }
 
     fn save_config(&self) -> Option<()> {
@@ -154,13 +170,17 @@ impl Config {
         &self.splits.history
     }
 
-    fn parse_run(&self) -> Option<(Run, bool)> {
-        let path = self.splits.current.clone()?;
+    fn parse_run_from_path(path: &Path) -> Option<(Run, bool)> {
         let file = fs::read(&path).ok()?;
         let parsed_run = composite::parse(&file, Some(&path)).ok()?;
         let run = parsed_run.run;
         let can_save = parsed_run.kind == TimerKind::LiveSplit;
         Some((run, can_save))
+    }
+
+    fn parse_run(&self) -> Option<(Run, bool)> {
+        let path = self.splits.current.clone()?;
+        Config::parse_run_from_path(&path)
     }
 
     pub fn parse_run_or_default(&mut self) -> Run {

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,7 +22,7 @@ use std::{
     sync::Arc,
 };
 
-use crate::{timer_form, LayoutData, MainState};
+use crate::{timer_form, LayoutData, MainState, cli};
 
 #[derive(Default, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
@@ -131,23 +131,40 @@ static CONFIG_PATH: Lazy<PathBuf> = Lazy::new(|| {
 });
 
 impl Config {
-    pub fn load(split_file: Option<PathBuf>) -> Self {
-        let cfg = Self::parse().unwrap_or_default();
-        cfg.load_path_splits(split_file)
+    pub fn load(cli: cli::Cli) -> Self {
+        let mut cfg = Self::parse().unwrap_or_default();
+        cfg.load_splits_path(cli.splits);
+        cfg.load_layout_path(cli.layout);
+        cfg.load_autosplitter_path(cli.autosplitter);
+        cfg.save_config();
+        cfg
     }
 
     /// Replace the current splits file with the given path during load, before the window is initialized
     /// If the file path is invalid it keeps the split file specified in the config
-    fn load_path_splits(mut self, split_file: Option<PathBuf>) -> Self {
-        if split_file.is_none() { return self; };
+    fn load_splits_path(&mut self, split_file: Option<PathBuf>) {
+        if split_file.is_none() { return; };
         let split_file = split_file.unwrap();
         // This reads the file twice, once now and again below when splits are opened
         let maybe_run = Config::parse_run_from_path(&split_file);
-        if maybe_run.is_none() { return self; };
+        if maybe_run.is_none() { return; };
         let (run, _) = maybe_run.unwrap();
         self.splits.add_to_history(&run);
         self.splits.current = Some(split_file);
-        self
+    }
+
+    fn load_layout_path(&mut self, layout_file: Option<PathBuf>) {
+        if layout_file.is_none() { return; };
+        let layout_file = layout_file.unwrap();
+        let maybe_layout = Self::parse_layout_with_path(&layout_file);
+        if maybe_layout.is_err() { return; }
+        self.general.can_save_layout = true;
+        self.general.layout = Some(layout_file);
+    }
+
+    fn load_autosplitter_path(&mut self, autosplitter_file: Option<PathBuf>) {
+        if autosplitter_file.is_none() { return; };
+        self.general.auto_splitter = autosplitter_file;
     }
 
     fn save_config(&self) -> Option<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -172,7 +172,7 @@ impl Lens<MainState, settings_editor::State> for SettingsEditorLens {
 
 fn main() {
     let cli = cli::Cli::parse();
-    let config = Config::load(cli.split_file);
+    let config = Config::load(cli);
     let window = config.build_window();
     timer_form::launch(MainState::new(config), window);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,9 @@ use std::{
     cell::RefCell,
     rc::Rc,
     sync::{Arc, RwLock},
-    env,
 };
 
+use clap::Parser;
 use druid::{Data, Lens, WindowId};
 use livesplit_core::{
     layout::LayoutState, settings::ImageCache, HotkeySystem, Layout, SharedTimer, Timer,
@@ -19,6 +19,7 @@ static GLOBAL: MiMalloc = MiMalloc;
 
 use crate::config::Config;
 
+mod cli;
 mod color_button;
 mod combo_box;
 mod config;
@@ -170,8 +171,8 @@ impl Lens<MainState, settings_editor::State> for SettingsEditorLens {
 }
 
 fn main() {
-    // This is clearly super fragile with cli options, but I don't know how to handle them properly
-    let config = Config::load(env::args().nth(1));
+    let cli = cli::Cli::parse();
+    let config = Config::load(cli.split_file);
     let window = config.build_window();
     timer_form::launch(MainState::new(config), window);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use std::{
     cell::RefCell,
     rc::Rc,
     sync::{Arc, RwLock},
+    env,
 };
 
 use druid::{Data, Lens, WindowId};
@@ -169,7 +170,8 @@ impl Lens<MainState, settings_editor::State> for SettingsEditorLens {
 }
 
 fn main() {
-    let config = Config::load();
+    // This is clearly super fragile with cli options, but I don't know how to handle them properly
+    let config = Config::load(env::args().nth(1));
     let window = config.build_window();
     timer_form::launch(MainState::new(config), window);
 }


### PR DESCRIPTION
This PR uses `clap` to add support for CLI arguments to select splits file, autosplitter file and layout file.
```
$ livesplit-one --help
Usage: livesplit-one [OPTIONS] [SPLITS]

Arguments:
  [SPLITS]  Split file to open. If not given, takes it from config file (the last one used)

Options:
  -a, --autosplitter <FILE>  Autosplitter file to open. If not given, takes it from config file (the last one used)
  -l, --layout <FILE>        Layout file to open. If not given, takes it from config file (the last one used)
  -h, --help                 Print help
  -V, --version              Print version
```
------

A known issue is the following error message when passing any named option:
```
$ livesplit-one -l test-file
Unknown option -l
```
Note that the option is processed correctly. This is probably caused by some other cli library embedded in druid that doesn't know anything about options specified by `clap`. Not sure how to handle this though since I don't know druid. As a side note, the library doesn't complain about the `[SPLITS]` argument, so a "solution" could be to disable named arguments and only keep `[SPLITS]`.