### PR TITLE
Save window size and position

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -113,6 +113,8 @@ struct Log {
 struct Window {
     width: f64,
     height: f64,
+    x: Option<f64>,
+    y: Option<f64>,
 }
 
 impl Default for Window {
@@ -120,6 +122,8 @@ impl Default for Window {
         Self {
             width: 300.0,
             height: 500.0,
+            x: None,
+            y: None,
         }
     }
 }
@@ -271,6 +275,12 @@ impl Config {
     pub fn set_window_size(&mut self, (width, height): (f64, f64)) {
         self.window.width = width;
         self.window.height = height;
+        self.save_config();
+    }
+
+    pub fn set_window_position(&mut self, (x, y): (f64, f64)) {
+        self.window.x = Some(x);
+        self.window.y = Some(y);
         self.save_config();
     }
 
@@ -539,13 +549,20 @@ impl Config {
     }
 
     pub fn build_window(&self) -> WindowDesc<MainState> {
-        WindowDesc::new(timer_form::root_widget())
+        let w = WindowDesc::new(timer_form::root_widget())
             .title("LiveSplit One")
             .with_min_size((50.0, 50.0))
             .window_size((self.window.width, self.window.height))
             .show_titlebar(false)
             .transparent(true)
-            .set_always_on_top(true)
+            .set_always_on_top(true);
+        if let (Some(x), Some(y)) = (self.window.x, self.window.y) {
+            // TODO: validate with Screen::get_display_rect() here?
+            // or Screen::get_monitors() with moniter.virtual_work_rect()?
+            w.set_position((x, y))
+        } else {
+            w
+        }
     }
 
     #[cfg(feature = "auto-splitting")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -268,6 +268,12 @@ impl Config {
             .unwrap_or_else(Layout::default_layout)
     }
 
+    pub fn set_window_size(&mut self, (width, height): (f64, f64)) {
+        self.window.width = width;
+        self.window.height = height;
+        self.save_config();
+    }
+
     // Just directly construct the HotkeySystem from the config.
     pub fn configure_hotkeys<E: event::CommandSink + Clone + Send + 'static>(
         &self,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use directories::ProjectDirs;
-use druid::WindowDesc;
+use druid::{Screen, WindowDesc};
 use livesplit_core::{
     event,
     layout::{self, Layout, LayoutSettings},
@@ -556,13 +556,13 @@ impl Config {
             .show_titlebar(false)
             .transparent(true)
             .set_always_on_top(true);
-        if let (Some(x), Some(y)) = (self.window.x, self.window.y) {
-            // TODO: validate with Screen::get_display_rect() here?
-            // or Screen::get_monitors() with moniter.virtual_work_rect()?
-            w.set_position((x, y))
-        } else {
-            w
-        }
+        let (Some(x), Some(y)) = (self.window.x, self.window.y) else {
+            return w;
+        };
+        let Some(p) = validate_position((x, y)) else {
+            return w;
+        };
+        w.set_position(p)
     }
 
     #[cfg(feature = "auto-splitting")]
@@ -600,4 +600,17 @@ pub fn or_show_error(result: Result<()>) {
     if let Err(e) = result {
         show_error(e);
     }
+}
+
+fn validate_position(position: impl Into<druid::Point>) -> Option<druid::Point> {
+    let p = position.into();
+    if !Screen::get_display_rect().contains(p) {
+        return None;
+    }
+    for m in Screen::get_monitors() {
+        if m.virtual_work_rect().contains(p) {
+            return Some(p);
+        }
+    }
+    None
 }

--- a/src/timer_form.rs
+++ b/src/timer_form.rs
@@ -665,8 +665,12 @@ impl<T: Widget<MainState>> Widget<MainState> for WithMenu<T> {
                     if self.intent.contains(Intent::EXIT) {
                         self.intent = self.intent.without(Intent::EXIT);
                         let w = ctx.window();
-                        data.config.borrow_mut().set_window_size(w.get_size().into());
-                        data.config.borrow_mut().set_window_position(w.get_position().into());
+                        data.config
+                            .borrow_mut()
+                            .set_window_size(w.get_size().into());
+                        data.config
+                            .borrow_mut()
+                            .set_window_position(w.get_position().into());
                         ctx.submit_command(commands::QUIT_APP);
                         break;
                     }

--- a/src/timer_form.rs
+++ b/src/timer_form.rs
@@ -666,7 +666,7 @@ impl<T: Widget<MainState>> Widget<MainState> for WithMenu<T> {
                         self.intent = self.intent.without(Intent::EXIT);
                         // TODO: ctx.size() vs ctx.window().get_size()
                         data.config.borrow_mut().set_window_size(ctx.size().into());
-                        // TODO: something something ctx.window().get_position() something?
+                        data.config.borrow_mut().set_window_position(ctx.window().get_position().into());
                         ctx.submit_command(commands::QUIT_APP);
                         break;
                     }

--- a/src/timer_form.rs
+++ b/src/timer_form.rs
@@ -664,6 +664,9 @@ impl<T: Widget<MainState>> Widget<MainState> for WithMenu<T> {
 
                     if self.intent.contains(Intent::EXIT) {
                         self.intent = self.intent.without(Intent::EXIT);
+                        // TODO: ctx.size() vs ctx.window().get_size()
+                        data.config.borrow_mut().set_window_size(ctx.size().into());
+                        // TODO: something something ctx.window().get_position() something?
                         ctx.submit_command(commands::QUIT_APP);
                         break;
                     }

--- a/src/timer_form.rs
+++ b/src/timer_form.rs
@@ -664,9 +664,9 @@ impl<T: Widget<MainState>> Widget<MainState> for WithMenu<T> {
 
                     if self.intent.contains(Intent::EXIT) {
                         self.intent = self.intent.without(Intent::EXIT);
-                        // TODO: ctx.size() vs ctx.window().get_size()
-                        data.config.borrow_mut().set_window_size(ctx.size().into());
-                        data.config.borrow_mut().set_window_position(ctx.window().get_position().into());
+                        let w = ctx.window();
+                        data.config.borrow_mut().set_window_size(w.get_size().into());
+                        data.config.borrow_mut().set_window_position(w.get_position().into());
                         ctx.submit_command(commands::QUIT_APP);
                         break;
                     }


### PR DESCRIPTION
Fixes #29 

Tasks:
- [x] Look into other ways of saving just before the window closes
  - I tried a few other ways, nothing else worked... might revisit this if someone else finds a better way
- [x] Look into validating positions that may have been saved with previous/outdated monitor setups: make sure to not force the window into a possibly invisible/unreachable position
- [x] Determine whether `ctx.size()` vs `ctx.window().get_size()` are equivalent or if one of them makes more sense than the other
  - `ctx.window().get_size()` is returning the same size as `ctx.size()`, but using `get_size` is more consistent with `get_position` just below