### PR TITLE
Add Autosplitter settings dialog, fix some UI jank

### DIFF
--- a/src/autosplitter_editor.rs
+++ b/src/autosplitter_editor.rs
@@ -558,16 +558,12 @@ fn setting_row_widget() -> impl Widget<SettingRow> {
                 Box::new(
                     Flex::row()
                         .with_flex_child(
-                            Flex::row()
-                                .with_spacer(indent)
-                                .with_flex_child(
-                                    Label::new(|row: &SettingRow, _: &Env| {
-                                        row.description.to_string()
-                                    })
+                            Flex::row().with_spacer(indent).with_flex_child(
+                                Label::new(|row: &SettingRow, _: &Env| row.description.to_string())
                                     .with_line_break_mode(druid::widget::LineBreaking::WordWrap)
                                     .controller(RowTooltipController::new()),
-                                    1.0,
-                                ),
+                                1.0,
+                            ),
                             1.0,
                         )
                         .with_flex_child(setting_value_widget().expand_width(), 1.0)

--- a/src/autosplitter_editor.rs
+++ b/src/autosplitter_editor.rs
@@ -535,18 +535,23 @@ fn setting_row_widget() -> impl Widget<SettingRow> {
                         .background(druid::widget::Painter::new(title_background)),
                 )
             } else {
-                // Setting row: label + value widget
+                // Setting row: two columns, each taking half the width
                 Box::new(
                     Flex::row()
-                        .with_spacer(indent)
-                        .with_child(
-                            Label::new(|row: &SettingRow, _: &Env| row.description.to_string())
-                                .with_line_break_mode(druid::widget::LineBreaking::WordWrap)
-                                .fix_width(300.0 - indent)
-                                .controller(RowTooltipController::new()),
+                        .with_flex_child(
+                            Flex::row()
+                                .with_spacer(indent)
+                                .with_flex_child(
+                                    Label::new(|row: &SettingRow, _: &Env| {
+                                        row.description.to_string()
+                                    })
+                                    .with_line_break_mode(druid::widget::LineBreaking::WordWrap)
+                                    .controller(RowTooltipController::new()),
+                                    1.0,
+                                ),
+                            1.0,
                         )
-                        .with_flex_spacer(1.0)
-                        .with_child(setting_value_widget())
+                        .with_flex_child(setting_value_widget().expand_width(), 1.0)
                         .padding(8.0)
                         .background(druid::widget::Painter::new(setting_background)),
                 )
@@ -578,12 +583,16 @@ fn setting_value_widget() -> impl Widget<SettingRow> {
                 // Title rows don't have a value widget, but this is needed for exhaustiveness
                 Box::new(druid::widget::SizedBox::empty())
             }
-            SettingRowValue::Bool(_) => Box::new(Switch::new().lens(Identity.map(
-                |row: &SettingRow| matches!(row.value, SettingRowValue::Bool(true)),
-                |row: &mut SettingRow, val: bool| {
-                    row.value = SettingRowValue::Bool(val);
-                },
-            ))),
+            SettingRowValue::Bool(_) => Box::new(
+                Switch::new()
+                    .lens(Identity.map(
+                        |row: &SettingRow| matches!(row.value, SettingRowValue::Bool(true)),
+                        |row: &mut SettingRow, val: bool| {
+                            row.value = SettingRowValue::Bool(val);
+                        },
+                    ))
+                    .center(),
+            ),
             SettingRowValue::Choice { options, .. } => {
                 let options_clone: Arc<Vec<ChoiceOption>> = options.clone();
                 Box::new(
@@ -605,7 +614,7 @@ fn setting_value_widget() -> impl Widget<SettingRow> {
                                 }
                             },
                         ))
-                        .fix_width(200.0),
+                        .expand_width(),
                 )
             }
             SettingRowValue::FileSelect { filters, .. } => {
@@ -648,7 +657,7 @@ fn setting_value_widget() -> impl Widget<SettingRow> {
                             current_path,
                         )));
                     })
-                    .fix_width(200.0),
+                    .expand_width(),
                 )
             }
         },

--- a/src/autosplitter_editor.rs
+++ b/src/autosplitter_editor.rs
@@ -1,0 +1,703 @@
+use std::{
+    rc::Rc,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use druid::{
+    commands::{self, CLOSE_WINDOW},
+    lens::Identity,
+    widget::{Button, Controller, Flex, Label, List, ListIter, Scroll, Switch},
+    Data, Env, Event, EventCtx, LensExt, LifeCycle, LifeCycleCtx, Point, RenderContext, TimerToken,
+    Widget, WidgetExt, WindowConfig, WindowId, WindowLevel, WindowSizePolicy,
+};
+use livesplit_core::{
+    auto_splitting::{
+        settings::{
+            FileFilter, Map as SettingsMap, Value as SettingValue, Widget as SettingsWidget,
+            WidgetKind,
+        },
+        Runtime,
+    },
+    SharedTimer,
+};
+
+use crate::{
+    combo_box,
+    consts::{BUTTON_SPACING, DIALOG_BUTTON_HEIGHT, DIALOG_BUTTON_WIDTH, MARGIN},
+};
+
+#[derive(Clone, Data)]
+pub struct State {
+    rows: Arc<Vec<SettingRow>>,
+    #[data(ignore)]
+    pub runtime: Rc<Runtime<SharedTimer>>,
+    #[data(ignore)]
+    pub closed_with_ok: bool,
+}
+
+#[derive(Clone, Data, PartialEq)]
+struct SettingRow {
+    index: usize,
+    key: Arc<str>,
+    description: Arc<str>,
+    tooltip: Option<Arc<str>>,
+    value: SettingRowValue,
+    indent_level: u32,
+}
+
+#[derive(Clone, Data, PartialEq)]
+enum SettingRowValue {
+    Title {
+        heading_level: u32,
+    },
+    Bool(bool),
+    Choice {
+        current: usize,
+        options: Arc<Vec<ChoiceOption>>,
+    },
+    FileSelect {
+        /// Current file path (empty string if none selected)
+        path: Arc<str>,
+        /// File filters for the dialog
+        #[data(ignore)]
+        filters: Arc<Vec<FileFilter>>,
+    },
+}
+
+#[derive(Clone, PartialEq)]
+struct ChoiceOption {
+    key: Arc<str>,
+    description: Arc<str>,
+}
+
+impl Data for ChoiceOption {
+    fn same(&self, other: &Self) -> bool {
+        self.key == other.key && self.description == other.description
+    }
+}
+
+impl State {
+    pub(crate) fn new(runtime: Rc<Runtime<SharedTimer>>) -> Self {
+        let widgets = runtime.settings_widgets().unwrap_or_default();
+        let settings_map = runtime.settings_map();
+        let rows = build_rows(&widgets, settings_map.as_ref());
+        Self {
+            rows: Arc::new(rows),
+            runtime,
+            closed_with_ok: false,
+        }
+    }
+
+    /// Sync UI state with the runtime's current settings.
+    /// Returns true if the state was updated.
+    fn sync_from_runtime(&mut self) -> bool {
+        let widgets = self.runtime.settings_widgets().unwrap_or_default();
+        let settings_map = self.runtime.settings_map();
+        let new_rows = build_rows(&widgets, settings_map.as_ref());
+
+        if *self.rows != new_rows {
+            self.rows = Arc::new(new_rows);
+            true
+        } else {
+            false
+        }
+    }
+}
+
+fn build_rows(widgets: &[SettingsWidget], settings_map: Option<&SettingsMap>) -> Vec<SettingRow> {
+    let mut rows = Vec::new();
+    // Track the current heading level for indentation of subsequent settings
+    let mut current_heading_level: Option<u32> = None;
+
+    for (index, widget) in widgets.iter().enumerate() {
+        let (value, indent_level) = match &widget.kind {
+            WidgetKind::Title { heading_level } => {
+                current_heading_level = Some(*heading_level);
+                (
+                    SettingRowValue::Title {
+                        heading_level: *heading_level,
+                    },
+                    *heading_level,
+                )
+            }
+            WidgetKind::Bool { default_value } => {
+                let current = settings_map
+                    .and_then(|m| m.get(widget.key.as_ref()))
+                    .and_then(|v| match v {
+                        SettingValue::Bool(b) => Some(*b),
+                        _ => None,
+                    })
+                    .unwrap_or(*default_value);
+                // Indent one level deeper than the current title
+                let indent = current_heading_level.map_or(0, |h| h + 1);
+                (SettingRowValue::Bool(current), indent)
+            }
+            WidgetKind::Choice {
+                default_option_key,
+                options,
+            } => {
+                let choice_options: Vec<ChoiceOption> = options
+                    .iter()
+                    .map(|opt| ChoiceOption {
+                        key: opt.key.clone(),
+                        description: opt.description.clone(),
+                    })
+                    .collect();
+
+                let current_key = settings_map
+                    .and_then(|m| m.get(widget.key.as_ref()))
+                    .and_then(|v| match v {
+                        SettingValue::String(s) => Some(s.as_ref()),
+                        _ => None,
+                    })
+                    .unwrap_or(default_option_key.as_ref());
+
+                let current = choice_options
+                    .iter()
+                    .position(|opt| opt.key.as_ref() == current_key)
+                    .unwrap_or(0);
+
+                // Indent one level deeper than the current title
+                let indent = current_heading_level.map_or(0, |h| h + 1);
+                (
+                    SettingRowValue::Choice {
+                        current,
+                        options: Arc::new(choice_options),
+                    },
+                    indent,
+                )
+            }
+            WidgetKind::FileSelect { filters } => {
+                let path = settings_map
+                    .and_then(|m| m.get(widget.key.as_ref()))
+                    .and_then(|v| match v {
+                        SettingValue::String(s) => Some(s.clone()),
+                        _ => None,
+                    })
+                    .unwrap_or_else(|| "".into());
+                let indent = current_heading_level.map_or(0, |h| h + 1);
+                (
+                    SettingRowValue::FileSelect {
+                        path,
+                        filters: filters.clone(),
+                    },
+                    indent,
+                )
+            }
+        };
+
+        rows.push(SettingRow {
+            index,
+            key: widget.key.clone(),
+            description: widget.description.clone(),
+            tooltip: widget.tooltip.clone(),
+            value,
+            indent_level,
+        });
+    }
+
+    rows
+}
+
+impl ListIter<SettingRow> for State {
+    fn for_each(&self, mut cb: impl FnMut(&SettingRow, usize)) {
+        for (idx, row) in self.rows.iter().enumerate() {
+            cb(row, idx);
+        }
+    }
+
+    fn for_each_mut(&mut self, mut cb: impl FnMut(&mut SettingRow, usize)) {
+        let mut rows = (*self.rows).clone();
+        let mut changed_rows: Vec<(Arc<str>, SettingRowValue)> = Vec::new();
+
+        for (idx, row) in rows.iter_mut().enumerate() {
+            let old_value = row.value.clone();
+            cb(row, idx);
+            if row.value != old_value {
+                changed_rows.push((row.key.clone(), row.value.clone()));
+            }
+        }
+
+        if !changed_rows.is_empty() {
+            // Apply changes to the runtime immediately so sync doesn't overwrite them
+            let mut new_map = self.runtime.settings_map().unwrap_or_default();
+            for (key, value) in changed_rows {
+                let setting_value = match &value {
+                    SettingRowValue::Title { .. } => continue,
+                    SettingRowValue::Bool(b) => SettingValue::Bool(*b),
+                    SettingRowValue::Choice { current, options } => {
+                        if let Some(opt) = options.get(*current) {
+                            SettingValue::String(opt.key.to_string().into())
+                        } else {
+                            continue;
+                        }
+                    }
+                    SettingRowValue::FileSelect { path, .. } => {
+                        SettingValue::String(path.to_string().into())
+                    }
+                };
+                new_map.insert(key.to_string().into(), setting_value);
+            }
+            self.runtime.set_settings_map(new_map);
+            self.rows = Arc::new(rows);
+        }
+    }
+
+    fn data_len(&self) -> usize {
+        self.rows.len()
+    }
+}
+
+pub fn root_widget() -> impl Widget<State> {
+    Flex::column()
+        .with_flex_child(settings_editor(), 1.0)
+        .with_child(dialog_buttons())
+        .controller(SyncController)
+}
+
+/// Controller that periodically syncs the UI with the runtime's settings.
+struct SyncController;
+
+impl<W: Widget<State>> Controller<State, W> for SyncController {
+    fn event(
+        &mut self,
+        child: &mut W,
+        ctx: &mut EventCtx,
+        event: &Event,
+        data: &mut State,
+        env: &Env,
+    ) {
+        if let Event::AnimFrame(_) = event {
+            // Sync with runtime settings
+            if data.sync_from_runtime() {
+                ctx.request_update();
+            }
+            // Request another frame to keep polling
+            ctx.request_anim_frame();
+        }
+        child.event(ctx, event, data, env);
+    }
+
+    fn lifecycle(
+        &mut self,
+        child: &mut W,
+        ctx: &mut LifeCycleCtx,
+        event: &LifeCycle,
+        data: &State,
+        env: &Env,
+    ) {
+        if let LifeCycle::WidgetAdded = event {
+            // Start the animation frame loop
+            ctx.request_anim_frame();
+        }
+        child.lifecycle(ctx, event, data, env);
+    }
+}
+
+fn settings_editor() -> impl Widget<State> {
+    Scroll::new(List::new(setting_row_widget).padding(MARGIN))
+        .vertical()
+        .expand_height()
+}
+
+/// Controller that shows a tooltip when hovering over a setting row.
+enum TooltipState {
+    Fresh,
+    Waiting {
+        last_move: Instant,
+        timer_expire: Instant,
+        token: TimerToken,
+        position: Point,
+    },
+    Showing(WindowId),
+}
+
+struct RowTooltipController {
+    state: TooltipState,
+}
+
+impl RowTooltipController {
+    fn new() -> Self {
+        Self {
+            state: TooltipState::Fresh,
+        }
+    }
+}
+
+impl<W: Widget<SettingRow>> Controller<SettingRow, W> for RowTooltipController {
+    fn event(
+        &mut self,
+        child: &mut W,
+        ctx: &mut EventCtx,
+        event: &Event,
+        data: &mut SettingRow,
+        env: &Env,
+    ) {
+        let tooltip = match &data.tooltip {
+            Some(t) if !t.is_empty() => t.clone(),
+            _ => {
+                // No tooltip, just pass through
+                child.event(ctx, event, data, env);
+                return;
+            }
+        };
+
+        let wait_duration = Duration::from_millis(500);
+        let resched_dur = Duration::from_millis(50);
+        let cursor_size = druid::Size::new(15., 15.);
+        let now = Instant::now();
+
+        let new_state = match &self.state {
+            TooltipState::Fresh => match event {
+                Event::MouseMove(me) if ctx.is_hot() => Some(TooltipState::Waiting {
+                    last_move: now,
+                    timer_expire: now + wait_duration,
+                    token: ctx.request_timer(wait_duration),
+                    position: me.window_pos,
+                }),
+                _ => None,
+            },
+            TooltipState::Waiting {
+                last_move,
+                timer_expire,
+                token,
+                position,
+            } => match event {
+                Event::MouseMove(me) if ctx.is_hot() => {
+                    let (cur_token, cur_expire) = if *timer_expire - now < resched_dur {
+                        (ctx.request_timer(wait_duration), now + wait_duration)
+                    } else {
+                        (*token, *timer_expire)
+                    };
+                    Some(TooltipState::Waiting {
+                        last_move: now,
+                        timer_expire: cur_expire,
+                        token: cur_token,
+                        position: me.window_pos,
+                    })
+                }
+                Event::Timer(tok) if tok == token => {
+                    let deadline = *last_move + wait_duration;
+                    ctx.set_handled();
+                    if deadline > now {
+                        let wait_for = deadline - now;
+                        Some(TooltipState::Waiting {
+                            last_move: *last_move,
+                            timer_expire: deadline,
+                            token: ctx.request_timer(wait_for),
+                            position: *position,
+                        })
+                    } else {
+                        let tooltip_position =
+                            (position.to_vec2() + cursor_size.to_vec2()).to_point();
+                        let win_id = ctx.new_sub_window(
+                            WindowConfig::default()
+                                .show_titlebar(false)
+                                .window_size_policy(WindowSizePolicy::Content)
+                                .set_level(WindowLevel::Tooltip(ctx.window().clone()))
+                                .set_position(tooltip_position),
+                            Label::<()>::new(tooltip.to_string())
+                                .with_line_break_mode(druid::widget::LineBreaking::WordWrap)
+                                .fix_width(300.0)
+                                .padding(4.0)
+                                .background(druid::Color::grey8(0x40)),
+                            (),
+                            env.clone(),
+                        );
+                        Some(TooltipState::Showing(win_id))
+                    }
+                }
+                _ => None,
+            },
+            TooltipState::Showing(win_id) => match event {
+                Event::MouseMove(_) if !ctx.is_hot() => {
+                    ctx.submit_command(CLOSE_WINDOW.to(*win_id));
+                    Some(TooltipState::Fresh)
+                }
+                _ => None,
+            },
+        };
+
+        if let Some(state) = new_state {
+            self.state = state;
+        }
+
+        if !ctx.is_handled() {
+            child.event(ctx, event, data, env);
+        }
+    }
+
+    fn lifecycle(
+        &mut self,
+        child: &mut W,
+        ctx: &mut LifeCycleCtx,
+        event: &LifeCycle,
+        data: &SettingRow,
+        env: &Env,
+    ) {
+        if let LifeCycle::HotChanged(false) = event {
+            if let TooltipState::Showing(win_id) = self.state {
+                ctx.submit_command(CLOSE_WINDOW.to(win_id));
+            }
+            self.state = TooltipState::Fresh;
+        }
+        child.lifecycle(ctx, event, data, env)
+    }
+}
+
+const INDENT_WIDTH: f64 = 20.0;
+
+fn setting_row_widget() -> impl Widget<SettingRow> {
+    druid::widget::ViewSwitcher::new(
+        |row: &SettingRow, _| matches!(row.value, SettingRowValue::Title { .. }),
+        |is_title, row: &SettingRow, _| {
+            let indent = row.indent_level as f64 * INDENT_WIDTH;
+            if *is_title {
+                // Title row: bold label spanning the full width
+                Box::new(
+                    Flex::row()
+                        .with_spacer(indent)
+                        .with_flex_child(
+                            Label::new(|row: &SettingRow, _: &Env| row.description.to_string())
+                                .with_font(druid::theme::UI_FONT_BOLD)
+                                .with_line_break_mode(druid::widget::LineBreaking::WordWrap)
+                                .controller(RowTooltipController::new()),
+                            1.0,
+                        )
+                        .padding(8.0)
+                        .background(druid::widget::Painter::new(title_background)),
+                )
+            } else {
+                // Setting row: label + value widget
+                Box::new(
+                    Flex::row()
+                        .with_spacer(indent)
+                        .with_child(
+                            Label::new(|row: &SettingRow, _: &Env| row.description.to_string())
+                                .with_line_break_mode(druid::widget::LineBreaking::WordWrap)
+                                .fix_width(300.0 - indent)
+                                .controller(RowTooltipController::new()),
+                        )
+                        .with_flex_spacer(1.0)
+                        .with_child(setting_value_widget())
+                        .padding(8.0)
+                        .background(druid::widget::Painter::new(setting_background)),
+                )
+            }
+        },
+    )
+}
+
+fn title_background(ctx: &mut druid::PaintCtx, _row: &SettingRow, _env: &Env) {
+    let rect = ctx.size().to_rect();
+    ctx.fill(rect, &druid::Color::grey8(0x20));
+}
+
+fn setting_background(ctx: &mut druid::PaintCtx, row: &SettingRow, _env: &Env) {
+    let rect = ctx.size().to_rect();
+    let color = if row.index % 2 == 0 {
+        druid::Color::grey8(0x14)
+    } else {
+        druid::Color::grey8(0x0b)
+    };
+    ctx.fill(rect, &color);
+}
+
+fn setting_value_widget() -> impl Widget<SettingRow> {
+    druid::widget::ViewSwitcher::new(
+        |row: &SettingRow, _| std::mem::discriminant(&row.value),
+        |_, row: &SettingRow, _| match &row.value {
+            SettingRowValue::Title { .. } => {
+                // Title rows don't have a value widget, but this is needed for exhaustiveness
+                Box::new(druid::widget::SizedBox::empty())
+            }
+            SettingRowValue::Bool(_) => Box::new(Switch::new().lens(Identity.map(
+                |row: &SettingRow| matches!(row.value, SettingRowValue::Bool(true)),
+                |row: &mut SettingRow, val: bool| {
+                    row.value = SettingRowValue::Bool(val);
+                },
+            ))),
+            SettingRowValue::Choice { options, .. } => {
+                let options_clone: Arc<Vec<ChoiceOption>> = options.clone();
+                Box::new(
+                    combo_box::dynamic_list(ChoiceList(options_clone.clone()))
+                        .lens(Identity.map(
+                            move |row: &SettingRow| {
+                                if let SettingRowValue::Choice { current, .. } = &row.value {
+                                    *current
+                                } else {
+                                    0
+                                }
+                            },
+                            move |row: &mut SettingRow, val: usize| {
+                                if let SettingRowValue::Choice { current, options } = &mut row.value
+                                {
+                                    if val < options.len() {
+                                        *current = val;
+                                    }
+                                }
+                            },
+                        ))
+                        .fix_width(200.0),
+                )
+            }
+            SettingRowValue::FileSelect { filters, .. } => {
+                let filters_clone = filters.clone();
+                Box::new(
+                    Button::new(|row: &SettingRow, _: &Env| {
+                        if let SettingRowValue::FileSelect { path, .. } = &row.value {
+                            if path.is_empty() {
+                                "Browse...".to_string()
+                            } else {
+                                // Show just the filename, not the full path
+                                std::path::Path::new(path.as_ref())
+                                    .file_name()
+                                    .map(|n| n.to_string_lossy().into_owned())
+                                    .unwrap_or_else(|| path.to_string())
+                            }
+                        } else {
+                            "Browse...".to_string()
+                        }
+                    })
+                    .on_click(move |_ctx, row: &mut SettingRow, _env| {
+                        // Get current path for starting directory
+                        let current_path =
+                            if let SettingRowValue::FileSelect { path, .. } = &row.value {
+                                if path.is_empty() {
+                                    None
+                                } else {
+                                    std::path::Path::new(path.as_ref())
+                                        .parent()
+                                        .map(|p| p.to_path_buf())
+                                }
+                            } else {
+                                None
+                            };
+
+                        // Show file dialog with filters
+                        let result = show_file_dialog(&filters_clone, current_path.as_deref());
+
+                        if let Some(path) = result {
+                            if let SettingRowValue::FileSelect {
+                                path: ref mut p, ..
+                            } = &mut row.value
+                            {
+                                *p = path.to_string_lossy().into();
+                            }
+                        }
+                    })
+                    .fix_width(200.0),
+                )
+            }
+        },
+    )
+}
+
+/// Show a file dialog with the given filters. Returns the selected path, or None if cancelled.
+fn show_file_dialog(
+    filters: &[FileFilter],
+    start_dir: Option<&std::path::Path>,
+) -> Option<std::path::PathBuf> {
+    // Collect all extensions from all filters into a single list
+    let mut all_extensions: Vec<String> = Vec::new();
+
+    for filter in filters {
+        match filter {
+            FileFilter::Name { pattern, .. } => {
+                // Extract extensions from the pattern (e.g., "*.txt *.log" -> ["txt", "log"])
+                for ext in pattern
+                    .split_whitespace()
+                    .filter_map(|p| p.strip_prefix("*."))
+                {
+                    if !all_extensions.contains(&ext.to_string()) {
+                        all_extensions.push(ext.to_string());
+                    }
+                }
+            }
+            FileFilter::MimeType(mime) => {
+                // Handle common MIME types by mapping to extensions
+                let extensions: &[&str] = match mime.as_ref() {
+                    "image/*" => &["png", "jpg", "jpeg", "gif", "bmp", "webp"],
+                    "image/png" => &["png"],
+                    "image/jpeg" => &["jpg", "jpeg"],
+                    "text/*" => &["txt", "log", "md"],
+                    "text/plain" => &["txt"],
+                    "application/json" => &["json"],
+                    "application/xml" => &["xml"],
+                    _ => &[],
+                };
+                for ext in extensions {
+                    if !all_extensions.contains(&ext.to_string()) {
+                        all_extensions.push(ext.to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    let ext_refs: Vec<&str> = all_extensions.iter().map(|s| s.as_str()).collect();
+
+    let mut dialog = native_dialog::FileDialog::new();
+
+    // Add a single filter with all extensions combined
+    if !ext_refs.is_empty() {
+        dialog = dialog.add_filter("Supported Files", &ext_refs);
+    }
+
+    // Set starting directory if provided
+    if let Some(dir) = start_dir {
+        dialog = dialog.set_location(dir);
+    }
+
+    dialog.show_open_single_file().ok().flatten()
+}
+
+#[derive(Clone)]
+struct ChoiceList(Arc<Vec<ChoiceOption>>);
+
+impl combo_box::ComboList for ChoiceList {
+    type Label = ChoiceLabel;
+    fn slice(&self) -> &[Self::Label] {
+        // Safety: ChoiceLabel is a repr(transparent) wrapper around ChoiceOption
+        unsafe { std::mem::transmute(self.0.as_slice()) }
+    }
+}
+
+#[repr(transparent)]
+struct ChoiceLabel(ChoiceOption);
+
+impl combo_box::ComboLabel for ChoiceLabel {
+    fn to_arc_str(&self) -> Arc<str> {
+        self.0.description.clone()
+    }
+    fn to_label_text<T>(&self) -> druid::widget::LabelText<T> {
+        druid::widget::LabelText::from(self.0.description.to_string())
+    }
+    fn as_str(&self) -> &str {
+        &self.0.description
+    }
+}
+
+fn dialog_buttons() -> impl Widget<State> {
+    Flex::row()
+        .with_flex_spacer(1.0)
+        .with_child(
+            Button::new("OK")
+                .on_click(|ctx, state: &mut State, _| {
+                    // Changes are applied immediately in for_each_mut, so just close
+                    state.closed_with_ok = true;
+                    ctx.submit_command(commands::CLOSE_WINDOW);
+                })
+                .fix_size(DIALOG_BUTTON_WIDTH, DIALOG_BUTTON_HEIGHT),
+        )
+        .with_spacer(BUTTON_SPACING)
+        .with_child(
+            Button::new("Cancel")
+                .on_click(|ctx, _, _| {
+                    ctx.submit_command(commands::CLOSE_WINDOW);
+                })
+                .fix_size(DIALOG_BUTTON_WIDTH, DIALOG_BUTTON_HEIGHT),
+        )
+        .padding(MARGIN)
+}

--- a/src/autosplitter_editor.rs
+++ b/src/autosplitter_editor.rs
@@ -9,13 +9,9 @@ use druid::{
     lens::Identity,
     widget::{Button, Controller, Flex, Label, List, ListIter, Scroll, Switch},
     Data, Env, Event, EventCtx, LensExt, LifeCycle, LifeCycleCtx, Point, RenderContext, Selector,
-    TimerToken, Widget, WidgetExt, WindowConfig, WindowId, WindowLevel, WindowSizePolicy,
+    Target, TimerToken, Widget, WidgetExt, WindowConfig, WindowId, WindowLevel, WindowSizePolicy,
 };
 
-/// Command to request showing a file dialog for a setting.
-/// Payload is (key, filters, start_dir).
-const REQUEST_FILE_DIALOG: Selector<(Arc<str>, Arc<Vec<FileFilter>>, Option<std::path::PathBuf>)> =
-    Selector::new("autosplitter-request-file-dialog");
 use livesplit_core::{
     auto_splitting::{
         settings::{
@@ -32,18 +28,15 @@ use crate::{
     consts::{BUTTON_SPACING, DIALOG_BUTTON_HEIGHT, DIALOG_BUTTON_WIDTH, MARGIN},
 };
 
-/// Tracks a pending file dialog request to be shown in the next AnimFrame.
-/// This is necessary because showing a native file dialog synchronously inside
-/// an event handler causes crashes on Windows (RefCell already borrowed).
-#[derive(Clone, Default)]
-struct PendingFileSelect {
-    /// The key of the setting row that requested the file dialog
-    key: Option<Arc<str>>,
-    /// The file filters to use
-    filters: Arc<Vec<FileFilter>>,
-    /// The starting directory for the dialog
-    start_dir: Option<std::path::PathBuf>,
-}
+/// Command to request showing a file dialog for a setting.
+/// Payload is (key, filters, start_dir).
+const REQUEST_FILE_DIALOG: Selector<(Arc<str>, Arc<Vec<FileFilter>>, Option<std::path::PathBuf>)> =
+    Selector::new("autosplitter-request-file-dialog");
+
+/// Command sent when a file dialog completes with a result.
+/// Payload is (key, selected_path).
+const FILE_DIALOG_RESULT: Selector<(Arc<str>, std::path::PathBuf)> =
+    Selector::new("autosplitter-file-dialog-result");
 
 #[derive(Clone, Data)]
 pub struct State {
@@ -52,8 +45,6 @@ pub struct State {
     pub runtime: Rc<Runtime<SharedTimer>>,
     #[data(ignore)]
     pub closed_with_ok: bool,
-    #[data(ignore)]
-    pending_file_select: Rc<std::cell::RefCell<PendingFileSelect>>,
 }
 
 #[derive(Clone, Data, PartialEq)]
@@ -106,7 +97,6 @@ impl State {
             rows: Arc::new(rows),
             runtime,
             closed_with_ok: false,
-            pending_file_select: Rc::new(std::cell::RefCell::new(PendingFileSelect::default())),
         }
     }
 
@@ -292,68 +282,59 @@ impl<W: Widget<State>> Controller<State, W> for SyncController {
         // Handle file dialog request command
         if let Event::Command(cmd) = event {
             if let Some((key, filters, start_dir)) = cmd.get(REQUEST_FILE_DIALOG) {
-                // Store the pending file dialog request
-                let mut pending = data.pending_file_select.borrow_mut();
-                pending.key = Some(key.clone());
-                pending.filters = filters.clone();
-                pending.start_dir = start_dir.clone();
+                let key = key.clone();
+                let filters = filters.clone();
+                let start_dir = start_dir.clone();
+                let event_sink = ctx.get_external_handle();
+
+                // Spawn a thread to show the file dialog
+                std::thread::spawn(move || {
+                    if let Some(path) = show_file_dialog(&filters, start_dir.as_deref()) {
+                        let _ = event_sink.submit_command(
+                            FILE_DIALOG_RESULT,
+                            (key, path),
+                            Target::Auto,
+                        );
+                    }
+                });
+
+                ctx.set_handled();
+                return;
+            }
+
+            // Handle file dialog result
+            if let Some((key, path)) = cmd.get(FILE_DIALOG_RESULT) {
+                let path_str: Arc<str> = path.to_string_lossy().into();
+
+                // Update the setting row with the selected path
+                let rows = Arc::make_mut(&mut data.rows);
+                for row in rows.iter_mut() {
+                    if row.key == *key {
+                        if let SettingRowValue::FileSelect {
+                            path: ref mut p, ..
+                        } = &mut row.value
+                        {
+                            *p = path_str.clone();
+                        }
+                        break;
+                    }
+                }
+
+                // Also update the runtime's settings map
+                let mut settings_map = data.runtime.settings_map().unwrap_or_default();
+                settings_map.insert(
+                    key.to_string().into(),
+                    SettingValue::String(path_str.to_string().into()),
+                );
+                data.runtime.set_settings_map(settings_map);
+
+                ctx.request_update();
                 ctx.set_handled();
                 return;
             }
         }
 
         if let Event::AnimFrame(_) = event {
-            // Check for pending file dialog request
-            let pending_request = {
-                let pending = data.pending_file_select.borrow();
-                if pending.key.is_some() {
-                    Some((
-                        pending.key.clone().unwrap(),
-                        pending.filters.clone(),
-                        pending.start_dir.clone(),
-                    ))
-                } else {
-                    None
-                }
-            };
-
-            if let Some((key, filters, start_dir)) = pending_request {
-                // Clear the pending request first
-                {
-                    let mut pending = data.pending_file_select.borrow_mut();
-                    pending.key = None;
-                }
-
-                // Show the file dialog
-                if let Some(selected_path) = show_file_dialog(&filters, start_dir.as_deref()) {
-                    let path_str: Arc<str> = selected_path.to_string_lossy().into();
-
-                    // Update the setting row with the selected path
-                    let rows = Arc::make_mut(&mut data.rows);
-                    for row in rows.iter_mut() {
-                        if row.key == key {
-                            if let SettingRowValue::FileSelect {
-                                path: ref mut p, ..
-                            } = &mut row.value
-                            {
-                                *p = path_str.clone();
-                            }
-                            break;
-                        }
-                    }
-
-                    // Also update the runtime's settings map
-                    let mut settings_map = data.runtime.settings_map().unwrap_or_default();
-                    settings_map.insert(
-                        key.to_string().into(),
-                        SettingValue::String(path_str.to_string().into()),
-                    );
-                    data.runtime.set_settings_map(settings_map);
-
-                    ctx.request_update();
-                }
-            }
-
             // Sync with runtime settings
             if data.sync_from_runtime() {
                 ctx.request_update();

--- a/src/autosplitter_editor.rs
+++ b/src/autosplitter_editor.rs
@@ -1,4 +1,5 @@
 use std::{
+    path::Path,
     rc::Rc,
     sync::Arc,
     time::{Duration, Instant},
@@ -18,7 +19,7 @@ use livesplit_core::{
             FileFilter, Map as SettingsMap, Value as SettingValue, Widget as SettingsWidget,
             WidgetKind,
         },
-        Runtime,
+        wasi_path, Runtime,
     },
     SharedTimer,
 };
@@ -71,7 +72,7 @@ enum SettingRowValue {
         options: Arc<Vec<ChoiceOption>>,
     },
     FileSelect {
-        /// Current file path (empty string if none selected)
+        /// Current file path, in native format (empty string if none selected)
         path: Arc<str>,
         /// File filters for the dialog
         #[data(ignore)]
@@ -192,11 +193,11 @@ fn build_rows(widgets: &[SettingsWidget], settings_map: Option<&SettingsMap>) ->
             WidgetKind::FileSelect { filters } => {
                 let path = settings_map
                     .and_then(|m| m.get(widget.key.as_ref()))
-                    .and_then(|v| match v {
-                        SettingValue::String(s) => Some(s.clone()),
-                        _ => None,
-                    })
-                    .unwrap_or_else(|| "".into());
+                    .and_then(|v| v.as_string())
+                    .and_then(|s| wasi_path::to_native(s, false))
+                    .filter(|p| p.exists())
+                    .map(|p| p.to_string_lossy().into())
+                    .unwrap_or_default();
                 let indent = current_heading_level.map_or(0, |h| h + 1);
                 (
                     SettingRowValue::FileSelect {
@@ -255,7 +256,11 @@ impl ListIter<SettingRow> for State {
                         }
                     }
                     SettingRowValue::FileSelect { path, .. } => {
-                        SettingValue::String(path.to_string().into())
+                        if let Some(s) = wasi_path::from_native(Path::new(path.as_ref())) {
+                            SettingValue::String(s.into())
+                        } else {
+                            continue;
+                        }
                     }
                 };
                 new_map.insert(key.to_string().into(), setting_value);
@@ -334,7 +339,11 @@ impl<W: Widget<State>> Controller<State, W> for SyncController {
                 let mut settings_map = data.runtime.settings_map().unwrap_or_default();
                 settings_map.insert(
                     key.to_string().into(),
-                    SettingValue::String(path_str.to_string().into()),
+                    SettingValue::String(
+                        wasi_path::from_native(Path::new(path_str.as_ref()))
+                            .unwrap_or_default()
+                            .into(),
+                    ),
                 );
                 data.runtime.set_settings_map(settings_map);
 

--- a/src/autosplitter_editor.rs
+++ b/src/autosplitter_editor.rs
@@ -8,9 +8,14 @@ use druid::{
     commands::{self, CLOSE_WINDOW},
     lens::Identity,
     widget::{Button, Controller, Flex, Label, List, ListIter, Scroll, Switch},
-    Data, Env, Event, EventCtx, LensExt, LifeCycle, LifeCycleCtx, Point, RenderContext, TimerToken,
-    Widget, WidgetExt, WindowConfig, WindowId, WindowLevel, WindowSizePolicy,
+    Data, Env, Event, EventCtx, LensExt, LifeCycle, LifeCycleCtx, Point, RenderContext, Selector,
+    TimerToken, Widget, WidgetExt, WindowConfig, WindowId, WindowLevel, WindowSizePolicy,
 };
+
+/// Command to request showing a file dialog for a setting.
+/// Payload is (key, filters, start_dir).
+const REQUEST_FILE_DIALOG: Selector<(Arc<str>, Arc<Vec<FileFilter>>, Option<std::path::PathBuf>)> =
+    Selector::new("autosplitter-request-file-dialog");
 use livesplit_core::{
     auto_splitting::{
         settings::{
@@ -27,6 +32,19 @@ use crate::{
     consts::{BUTTON_SPACING, DIALOG_BUTTON_HEIGHT, DIALOG_BUTTON_WIDTH, MARGIN},
 };
 
+/// Tracks a pending file dialog request to be shown in the next AnimFrame.
+/// This is necessary because showing a native file dialog synchronously inside
+/// an event handler causes crashes on Windows (RefCell already borrowed).
+#[derive(Clone, Default)]
+struct PendingFileSelect {
+    /// The key of the setting row that requested the file dialog
+    key: Option<Arc<str>>,
+    /// The file filters to use
+    filters: Arc<Vec<FileFilter>>,
+    /// The starting directory for the dialog
+    start_dir: Option<std::path::PathBuf>,
+}
+
 #[derive(Clone, Data)]
 pub struct State {
     rows: Arc<Vec<SettingRow>>,
@@ -34,6 +52,8 @@ pub struct State {
     pub runtime: Rc<Runtime<SharedTimer>>,
     #[data(ignore)]
     pub closed_with_ok: bool,
+    #[data(ignore)]
+    pending_file_select: Rc<std::cell::RefCell<PendingFileSelect>>,
 }
 
 #[derive(Clone, Data, PartialEq)]
@@ -86,6 +106,7 @@ impl State {
             rows: Arc::new(rows),
             runtime,
             closed_with_ok: false,
+            pending_file_select: Rc::new(std::cell::RefCell::new(PendingFileSelect::default())),
         }
     }
 
@@ -268,7 +289,71 @@ impl<W: Widget<State>> Controller<State, W> for SyncController {
         data: &mut State,
         env: &Env,
     ) {
+        // Handle file dialog request command
+        if let Event::Command(cmd) = event {
+            if let Some((key, filters, start_dir)) = cmd.get(REQUEST_FILE_DIALOG) {
+                // Store the pending file dialog request
+                let mut pending = data.pending_file_select.borrow_mut();
+                pending.key = Some(key.clone());
+                pending.filters = filters.clone();
+                pending.start_dir = start_dir.clone();
+                ctx.set_handled();
+                return;
+            }
+        }
+
         if let Event::AnimFrame(_) = event {
+            // Check for pending file dialog request
+            let pending_request = {
+                let pending = data.pending_file_select.borrow();
+                if pending.key.is_some() {
+                    Some((
+                        pending.key.clone().unwrap(),
+                        pending.filters.clone(),
+                        pending.start_dir.clone(),
+                    ))
+                } else {
+                    None
+                }
+            };
+
+            if let Some((key, filters, start_dir)) = pending_request {
+                // Clear the pending request first
+                {
+                    let mut pending = data.pending_file_select.borrow_mut();
+                    pending.key = None;
+                }
+
+                // Show the file dialog
+                if let Some(selected_path) = show_file_dialog(&filters, start_dir.as_deref()) {
+                    let path_str: Arc<str> = selected_path.to_string_lossy().into();
+
+                    // Update the setting row with the selected path
+                    let rows = Arc::make_mut(&mut data.rows);
+                    for row in rows.iter_mut() {
+                        if row.key == key {
+                            if let SettingRowValue::FileSelect {
+                                path: ref mut p, ..
+                            } = &mut row.value
+                            {
+                                *p = path_str.clone();
+                            }
+                            break;
+                        }
+                    }
+
+                    // Also update the runtime's settings map
+                    let mut settings_map = data.runtime.settings_map().unwrap_or_default();
+                    settings_map.insert(
+                        key.to_string().into(),
+                        SettingValue::String(path_str.to_string().into()),
+                    );
+                    data.runtime.set_settings_map(settings_map);
+
+                    ctx.request_update();
+                }
+            }
+
             // Sync with runtime settings
             if data.sync_from_runtime() {
                 ctx.request_update();
@@ -560,7 +645,7 @@ fn setting_value_widget() -> impl Widget<SettingRow> {
                             "Browse...".to_string()
                         }
                     })
-                    .on_click(move |_ctx, row: &mut SettingRow, _env| {
+                    .on_click(move |ctx, row: &mut SettingRow, _env| {
                         // Get current path for starting directory
                         let current_path =
                             if let SettingRowValue::FileSelect { path, .. } = &row.value {
@@ -575,17 +660,12 @@ fn setting_value_widget() -> impl Widget<SettingRow> {
                                 None
                             };
 
-                        // Show file dialog with filters
-                        let result = show_file_dialog(&filters_clone, current_path.as_deref());
-
-                        if let Some(path) = result {
-                            if let SettingRowValue::FileSelect {
-                                path: ref mut p, ..
-                            } = &mut row.value
-                            {
-                                *p = path.to_string_lossy().into();
-                            }
-                        }
+                        // Send command to show file dialog (deferred to avoid RefCell crash)
+                        ctx.submit_command(REQUEST_FILE_DIALOG.with((
+                            row.key.clone(),
+                            filters_clone.clone(),
+                            current_path,
+                        )));
                     })
                     .fix_width(200.0),
                 )
@@ -645,9 +725,11 @@ fn show_file_dialog(
         dialog = dialog.add_filter("Supported Files", &ext_refs);
     }
 
-    // Set starting directory if provided
+    // Set starting directory if provided and it exists
     if let Some(dir) = start_dir {
-        dialog = dialog.set_location(dir);
+        if dir.is_dir() {
+            dialog = dialog.set_location(dir);
+        }
     }
 
     dialog.show_open_single_file().ok().flatten()

--- a/src/autosplitter_editor.rs
+++ b/src/autosplitter_editor.rs
@@ -45,6 +45,9 @@ pub struct State {
     pub runtime: Rc<Runtime<SharedTimer>>,
     #[data(ignore)]
     pub closed_with_ok: bool,
+    /// Original settings map when the dialog was opened, used to revert on cancel.
+    #[data(ignore)]
+    original_settings: Option<SettingsMap>,
 }
 
 #[derive(Clone, Data, PartialEq)]
@@ -95,9 +98,16 @@ impl State {
         let rows = build_rows(&widgets, settings_map.as_ref());
         Self {
             rows: Arc::new(rows),
+            original_settings: settings_map,
             runtime,
             closed_with_ok: false,
         }
+    }
+
+    /// Revert the runtime settings to the original state when the dialog was opened.
+    pub(crate) fn revert_settings(&self) {
+        let settings = self.original_settings.clone().unwrap_or_default();
+        self.runtime.set_settings_map(settings);
     }
 
     /// Sync UI state with the runtime's current settings.

--- a/src/color_button.rs
+++ b/src/color_button.rs
@@ -714,13 +714,7 @@ impl Widget<ColorState> for ColorButtonPod {
         self.0.lifecycle(ctx, event, data, env)
     }
 
-    fn update(
-        &mut self,
-        ctx: &mut UpdateCtx,
-        old_data: &ColorState,
-        data: &ColorState,
-        env: &Env,
-    ) {
+    fn update(&mut self, ctx: &mut UpdateCtx, old_data: &ColorState, data: &ColorState, env: &Env) {
         if !old_data.same(data) {
             ctx.request_paint();
         }
@@ -759,21 +753,23 @@ impl Widget<ColorState> for ColorButton {
                     } else {
                         // Close any other open color picker first
                         ctx.submit_command(CLOSE_COLOR_PICKER.to(Target::Global));
-                        self.open_window = Some(ctx.new_sub_window(
-                            WindowConfig::default()
-                                .show_titlebar(false)
-                                .resizable(false)
-                                .transparent(true)
-                                .window_size(Size::new(225., 355.))
-                                .set_position(ctx.to_window(Point::new(
-                                    ctx.size().width / 2.0 - 225.0 / 2.0,
-                                    ctx.size().height * 2.0,
-                                )))
-                                .set_level(WindowLevel::DropDown(ctx.window().clone())),
-                            color_picker(ctx.window_id()),
-                            *data,
-                            env.clone(),
-                        ));
+                        self.open_window = Some(
+                            ctx.new_sub_window(
+                                WindowConfig::default()
+                                    .show_titlebar(false)
+                                    .resizable(false)
+                                    .transparent(true)
+                                    .window_size(Size::new(225., 355.))
+                                    .set_position(ctx.to_window(Point::new(
+                                        ctx.size().width / 2.0 - 225.0 / 2.0,
+                                        ctx.size().height * 2.0,
+                                    )))
+                                    .set_level(WindowLevel::DropDown(ctx.window().clone())),
+                                color_picker(ctx.window_id()),
+                                *data,
+                                env.clone(),
+                            ),
+                        );
                         self.just_opened = true;
                     }
                     ctx.request_paint();

--- a/src/color_button.rs
+++ b/src/color_button.rs
@@ -7,7 +7,7 @@ use druid::{
     widget::{Controller, Flex, Label, Painter, Slider, TextBox},
     BoxConstraints, Color, Cursor, Data, Env, Event, EventCtx, LayoutCtx, Lens, LifeCycle,
     LifeCycleCtx, LinearGradient, MouseButton, PaintCtx, Point, RenderContext, Selector, Size,
-    Target, TextAlignment, UnitPoint, UpdateCtx, Vec2, Widget, WidgetExt, WidgetPod, WindowConfig,
+    Target, TextAlignment, UnitPoint, UpdateCtx, Widget, WidgetExt, WidgetPod, WindowConfig,
     WindowId, WindowLevel,
 };
 
@@ -765,10 +765,10 @@ impl Widget<ColorState> for ColorButton {
                                 .resizable(false)
                                 .transparent(true)
                                 .window_size(Size::new(225., 355.))
-                                .set_position(ctx.to_window(
-                                    ctx.size().to_rect().center()
-                                        + Vec2::new(-0.5 * 225.0, 0.5 * ctx.size().height),
-                                ))
+                                .set_position(ctx.to_window(Point::new(
+                                    ctx.size().width / 2.0 - 225.0 / 2.0,
+                                    ctx.size().height * 2.0,
+                                )))
                                 .set_level(WindowLevel::DropDown(ctx.window().clone())),
                             color_picker(ctx.window_id()),
                             *data,

--- a/src/color_button.rs
+++ b/src/color_button.rs
@@ -1,13 +1,18 @@
 use druid::{
+    commands::CLOSE_WINDOW,
     kurbo::{Circle, Line, PathEl},
     lens::Unit,
     piet::{Image, ImageFormat, InterpolationMode, PietImage},
     theme,
     widget::{Controller, Flex, Label, Painter, Slider, TextBox},
     BoxConstraints, Color, Cursor, Data, Env, Event, EventCtx, LayoutCtx, Lens, LifeCycle,
-    LifeCycleCtx, LinearGradient, MouseButton, PaintCtx, Point, RenderContext, Size, TextAlignment,
-    UnitPoint, UpdateCtx, Vec2, Widget, WidgetExt, WidgetPod, WindowConfig, WindowLevel,
+    LifeCycleCtx, LinearGradient, MouseButton, PaintCtx, Point, RenderContext, Selector, Size,
+    Target, TextAlignment, UnitPoint, UpdateCtx, Vec2, Widget, WidgetExt, WidgetPod, WindowConfig,
+    WindowId, WindowLevel,
 };
+
+const COLOR_CHANGED: Selector<()> = Selector::new("color-button.color-changed");
+const CLOSE_COLOR_PICKER: Selector<()> = Selector::new("color-button.close-color-picker");
 use image::{ImageBuffer, RgbaImage};
 
 use std::fmt::Write;
@@ -165,6 +170,20 @@ impl<W: Widget<ColorState>> Controller<ColorState, W> for PickerController {
             _ => {}
         }
         child.event(ctx, event, data, env)
+    }
+
+    fn update(
+        &mut self,
+        child: &mut W,
+        ctx: &mut UpdateCtx,
+        old_data: &ColorState,
+        data: &ColorState,
+        env: &Env,
+    ) {
+        if !old_data.same(data) {
+            ctx.request_paint();
+        }
+        child.update(ctx, old_data, data, env)
     }
 }
 
@@ -642,7 +661,25 @@ fn arrow() -> impl Widget<()> {
     .fix_height(8.0)
 }
 
-fn color_picker() -> impl Widget<ColorState> {
+struct NotifyParentController(WindowId);
+
+impl<W: Widget<ColorState>> Controller<ColorState, W> for NotifyParentController {
+    fn update(
+        &mut self,
+        child: &mut W,
+        ctx: &mut UpdateCtx,
+        old_data: &ColorState,
+        data: &ColorState,
+        env: &Env,
+    ) {
+        if !old_data.same(data) {
+            ctx.submit_command(COLOR_CHANGED.to(Target::Window(self.0)));
+        }
+        child.update(ctx, old_data, data, env)
+    }
+}
+
+fn color_picker(parent_window: WindowId) -> impl Widget<ColorState> {
     Flex::column()
         .with_child(arrow().lens(Unit))
         .with_flex_child(picker(), 1.0)
@@ -650,37 +687,16 @@ fn color_picker() -> impl Widget<ColorState> {
         .with_child(separator().lens(Unit))
         .with_child(palette())
         .border(Color::grey8(0x50), 1.0)
-        .controller(CloseOnFocusLoss)
-}
-
-struct CloseOnFocusLoss;
-
-impl<T, W: Widget<T>> Controller<T, W> for CloseOnFocusLoss {
-    fn event(&mut self, child: &mut W, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
-        /*
-        if let Event::WindowLostFocus = event {
-            ctx.submit_command(CLOSE_WINDOW);
-        }
-        */
-        child.event(ctx, event, data, env)
-    }
-
-    fn lifecycle(
-        &mut self,
-        child: &mut W,
-        ctx: &mut LifeCycleCtx,
-        event: &LifeCycle,
-        data: &T,
-        env: &Env,
-    ) {
-        child.lifecycle(ctx, event, data, env)
-    }
+        .controller(NotifyParentController(parent_window))
 }
 
 struct ColorButtonPod(WidgetPod<ColorState, ColorButton>);
 
 pub fn widget() -> impl Widget<ColorState> {
-    ColorButtonPod(WidgetPod::new(ColorButton))
+    ColorButtonPod(WidgetPod::new(ColorButton {
+        open_window: None,
+        just_opened: false,
+    }))
 }
 
 impl Widget<ColorState> for ColorButtonPod {
@@ -701,10 +717,13 @@ impl Widget<ColorState> for ColorButtonPod {
     fn update(
         &mut self,
         ctx: &mut UpdateCtx,
-        _old_data: &ColorState,
+        old_data: &ColorState,
         data: &ColorState,
         env: &Env,
     ) {
+        if !old_data.same(data) {
+            ctx.request_paint();
+        }
         self.0.update(ctx, data, env)
     }
 
@@ -725,22 +744,22 @@ impl Widget<ColorState> for ColorButtonPod {
     }
 }
 
-struct ColorButton;
+struct ColorButton {
+    open_window: Option<WindowId>,
+    just_opened: bool,
+}
 
 impl Widget<ColorState> for ColorButton {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut ColorState, env: &Env) {
         match event {
             Event::MouseDown(mouse_event) => {
                 if mouse_event.button == MouseButton::Left && !ctx.is_disabled() {
-                    ctx.set_active(true);
-                    ctx.request_paint();
-                }
-            }
-            Event::MouseUp(mouse_event) => {
-                if ctx.is_active() && mouse_event.button == MouseButton::Left {
-                    ctx.set_active(false);
-                    if ctx.is_hot() && !ctx.is_disabled() {
-                        ctx.new_sub_window(
+                    if let Some(window_id) = self.open_window.take() {
+                        ctx.submit_command(CLOSE_WINDOW.to(Target::Window(window_id)));
+                    } else {
+                        // Close any other open color picker first
+                        ctx.submit_command(CLOSE_COLOR_PICKER.to(Target::Global));
+                        self.open_window = Some(ctx.new_sub_window(
                             WindowConfig::default()
                                 .show_titlebar(false)
                                 .resizable(false)
@@ -751,10 +770,11 @@ impl Widget<ColorState> for ColorButton {
                                         + Vec2::new(-0.5 * 225.0, 0.5 * ctx.size().height),
                                 ))
                                 .set_level(WindowLevel::DropDown(ctx.window().clone())),
-                            color_picker(),
+                            color_picker(ctx.window_id()),
                             *data,
                             env.clone(),
-                        );
+                        ));
+                        self.just_opened = true;
                     }
                     ctx.request_paint();
                 }
@@ -765,6 +785,17 @@ impl Widget<ColorState> for ColorButton {
                 } else {
                     ctx.set_disabled(false);
                     ctx.clear_cursor();
+                }
+            }
+            Event::Command(cmd) if cmd.is(COLOR_CHANGED) => {
+                ctx.request_paint();
+            }
+            Event::Command(cmd) if cmd.is(CLOSE_COLOR_PICKER) => {
+                // Don't close if we just opened (we sent this command)
+                if self.just_opened {
+                    self.just_opened = false;
+                } else if let Some(window_id) = self.open_window.take() {
+                    ctx.submit_command(CLOSE_WINDOW.to(Target::Window(window_id)));
                 }
             }
             _ => {}

--- a/src/combo_box.rs
+++ b/src/combo_box.rs
@@ -8,9 +8,11 @@ use druid::{
     theme,
     widget::{Button, Controller, Flex, Label, LabelText, Painter, Scroll, TextBox},
     BoxConstraints, Color, Env, Event, EventCtx, LayoutCtx, LensExt, LifeCycle, LifeCycleCtx,
-    PaintCtx, Point, RenderContext, Size, Target, UpdateCtx, Widget, WidgetExt, WindowConfig,
-    WindowId, WindowLevel,
+    PaintCtx, Point, RenderContext, Selector, Size, Target, UpdateCtx, Widget, WidgetExt,
+    WindowConfig, WindowId, WindowLevel,
 };
+
+const DROPDOWN_CLOSED: Selector<()> = Selector::new("combo-box.dropdown-closed");
 
 struct CloseOnFocusLoss;
 
@@ -203,6 +205,11 @@ impl<W: Widget<String>, L: ComboList> Widget<String> for OnClick<W, L> {
                     return;
                 }
             }
+            Event::Command(cmd) => {
+                if cmd.is(DROPDOWN_CLOSED) {
+                    self.open_window = None;
+                }
+            }
             _ => {}
         }
         self.widget.event(ctx, event, data, env);
@@ -213,9 +220,6 @@ impl<W: Widget<String>, L: ComboList> Widget<String> for OnClick<W, L> {
     }
 
     fn update(&mut self, ctx: &mut UpdateCtx, old_data: &String, data: &String, env: &Env) {
-        if old_data != data {
-            self.open_window = None;
-        }
         self.widget.update(ctx, old_data, data, env)
     }
 
@@ -266,6 +270,12 @@ impl<W: Widget<usize>> Controller<usize, W> for DropdownToggleController {
                     ctx.submit_command(CLOSE_WINDOW.to(Target::Window(window_id)));
                     return; // Don't let button process this click
                 }
+            }
+        }
+        // Clear open_window when dropdown closes (even if same option selected)
+        if let Event::Command(cmd) = event {
+            if cmd.is(DROPDOWN_CLOSED) {
+                self.open_window.set(None);
             }
         }
         child.event(ctx, event, data, env);
@@ -339,6 +349,7 @@ fn drop_down(list: &impl ComboList) -> impl Widget<usize> {
             }))
             .on_click(move |ctx, selected_index, _env| {
                 *selected_index = index;
+                ctx.submit_command(DROPDOWN_CLOSED.to(Target::Global));
                 ctx.submit_command(CLOSE_WINDOW);
             });
         flex.add_child(label);

--- a/src/combo_box.rs
+++ b/src/combo_box.rs
@@ -183,40 +183,42 @@ impl<W: Widget<String>, L: ComboList> Widget<String> for OnClick<W, L> {
                     } else {
                         let text_width = max_text_width(&self.list, &mut ctx.text(), env);
                         let dropdown_width = (text_width + 14.0).max(width);
-                        self.open_window = Some(ctx.new_sub_window(
-                            WindowConfig::default()
-                                .show_titlebar(false)
-                                .resizable(false)
-                                .transparent(true)
-                                .window_size(Size::new(
-                                    dropdown_width,
-                                    25.0 * self.list.slice().len().min(8) as f64 + 2.0,
-                                ))
-                                .set_position(ctx.to_window(Point::new(0.0, height - 1.0)))
-                                .set_level(WindowLevel::DropDown(ctx.window().clone())),
-                            drop_down(&self.list).lens(Identity.map(
-                                {
-                                    let list = self.list.clone();
-                                    move |row: &String| {
-                                        list.slice()
-                                            .iter()
-                                            .position(|l| l.as_str() == row)
-                                            .unwrap_or(list.slice().len())
-                                    }
-                                },
-                                {
-                                    let list = self.list.clone();
-                                    move |row: &mut String, index: usize| {
-                                        if let Some(element) = list.slice().get(index) {
-                                            row.clear();
-                                            row.push_str(element.as_str());
+                        self.open_window = Some(
+                            ctx.new_sub_window(
+                                WindowConfig::default()
+                                    .show_titlebar(false)
+                                    .resizable(false)
+                                    .transparent(true)
+                                    .window_size(Size::new(
+                                        dropdown_width,
+                                        25.0 * self.list.slice().len().min(8) as f64 + 2.0,
+                                    ))
+                                    .set_position(ctx.to_window(Point::new(0.0, height - 1.0)))
+                                    .set_level(WindowLevel::DropDown(ctx.window().clone())),
+                                drop_down(&self.list).lens(Identity.map(
+                                    {
+                                        let list = self.list.clone();
+                                        move |row: &String| {
+                                            list.slice()
+                                                .iter()
+                                                .position(|l| l.as_str() == row)
+                                                .unwrap_or(list.slice().len())
                                         }
-                                    }
-                                },
-                            )),
-                            data.clone(),
-                            env.clone(),
-                        ));
+                                    },
+                                    {
+                                        let list = self.list.clone();
+                                        move |row: &mut String, index: usize| {
+                                            if let Some(element) = list.slice().get(index) {
+                                                row.clear();
+                                                row.push_str(element.as_str());
+                                            }
+                                        }
+                                    },
+                                )),
+                                data.clone(),
+                                env.clone(),
+                            ),
+                        );
                     }
                 }
             }

--- a/src/combo_box.rs
+++ b/src/combo_box.rs
@@ -5,12 +5,30 @@ use druid::{
     commands::CLOSE_WINDOW,
     kurbo::BezPath,
     lens::Identity,
+    piet::{PietText, Text, TextLayout, TextLayoutBuilder},
     theme,
     widget::{Button, Controller, Flex, Label, LabelText, Painter, Scroll, TextBox},
     BoxConstraints, Color, Env, Event, EventCtx, LayoutCtx, LensExt, LifeCycle, LifeCycleCtx,
     PaintCtx, Point, RenderContext, Selector, Size, Target, UpdateCtx, Widget, WidgetExt,
     WindowConfig, WindowId, WindowLevel,
 };
+
+fn max_text_width(list: &impl ComboList, text: &mut PietText, env: &Env) -> f64 {
+    let font = env.get(theme::UI_FONT);
+    let mut max_width = 0.0;
+    for item in list.slice() {
+        if let Ok(layout) = text
+            .new_text_layout(item.as_str().to_string())
+            .font(font.family.clone(), font.size)
+            .build()
+        {
+            if layout.size().width > max_width {
+                max_width = layout.size().width;
+            }
+        }
+    }
+    max_width
+}
 
 const DROPDOWN_CLOSED: Selector<()> = Selector::new("combo-box.dropdown-closed");
 
@@ -47,8 +65,9 @@ impl<T, W: Widget<T>> Widget<T> for ComboBox<W> {
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
-        self.0.paint(ctx, data, env);
         let Size { width, height } = ctx.size();
+        ctx.clip(Size { width, height }.to_rect());
+        self.0.paint(ctx, data, env);
         let l_x = width - 24.0 + 7.0;
         let t_y = 0.5 * height - 2.0;
         let r_x = width - 7.0;
@@ -162,13 +181,15 @@ impl<W: Widget<String>, L: ComboList> Widget<String> for OnClick<W, L> {
                     if let Some(window_id) = self.open_window.take() {
                         ctx.submit_command(CLOSE_WINDOW.to(Target::Window(window_id)));
                     } else {
+                        let text_width = max_text_width(&self.list, &mut ctx.text(), env);
+                        let dropdown_width = (text_width + 14.0).max(width);
                         self.open_window = Some(ctx.new_sub_window(
                             WindowConfig::default()
                                 .show_titlebar(false)
                                 .resizable(false)
                                 .transparent(true)
                                 .window_size(Size::new(
-                                    width,
+                                    dropdown_width,
                                     25.0 * self.list.slice().len().min(8) as f64 + 2.0,
                                 ))
                                 .set_position(ctx.to_window(Point::new(0.0, height - 1.0)))
@@ -305,13 +326,15 @@ pub fn dynamic_list(list: impl ComboList) -> impl Widget<usize> {
             move |&index: &usize, _: &_| list.slice()[index].to_arc_str()
         })
         .on_click(move |ctx, &mut index: &mut usize, env| {
+            let text_width = max_text_width(&list, &mut ctx.text(), env);
+            let dropdown_width = (text_width + 14.0).max(ctx.size().width);
             let window_id = ctx.new_sub_window(
                 WindowConfig::default()
                     .show_titlebar(false)
                     .resizable(false)
                     .transparent(true)
                     .window_size(Size::new(
-                        ctx.size().width,
+                        dropdown_width,
                         25.0 * list.slice().len().min(8) as f64 + 2.0,
                     ))
                     .set_position(ctx.to_window(Point::new(0.0, ctx.size().height - 1.0)))

--- a/src/combo_box.rs
+++ b/src/combo_box.rs
@@ -1,3 +1,6 @@
+use std::cell::Cell;
+use std::rc::Rc;
+
 use druid::{
     commands::CLOSE_WINDOW,
     kurbo::BezPath,
@@ -5,7 +8,8 @@ use druid::{
     theme,
     widget::{Button, Controller, Flex, Label, LabelText, Painter, Scroll, TextBox},
     BoxConstraints, Color, Env, Event, EventCtx, LayoutCtx, LensExt, LifeCycle, LifeCycleCtx,
-    PaintCtx, Point, RenderContext, Size, UpdateCtx, Widget, WidgetExt, WindowConfig, WindowLevel,
+    PaintCtx, Point, RenderContext, Size, Target, UpdateCtx, Widget, WidgetExt, WindowConfig,
+    WindowId, WindowLevel,
 };
 
 struct CloseOnFocusLoss;
@@ -144,47 +148,53 @@ impl<W: Widget<String>> Widget<String> for Pod<W> {
 struct OnClick<W, L> {
     widget: W,
     list: L,
+    open_window: Option<WindowId>,
 }
+
 impl<W: Widget<String>, L: ComboList> Widget<String> for OnClick<W, L> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut String, env: &Env) {
         let Size { width, height } = ctx.size();
         match event {
             Event::MouseDown(event) => {
                 if event.button == druid::MouseButton::Left && event.pos.x >= width - 24.0 {
-                    ctx.new_sub_window(
-                        WindowConfig::default()
-                            .show_titlebar(false)
-                            .resizable(false)
-                            .transparent(true)
-                            .window_size(Size::new(
-                                width,
-                                25.0 * self.list.slice().len().min(8) as f64 + 2.0,
-                            ))
-                            .set_position(ctx.to_window(Point::new(0.0, height - 1.0)))
-                            .set_level(WindowLevel::DropDown(ctx.window().clone())),
-                        drop_down(&self.list).lens(Identity.map(
-                            {
-                                let list = self.list.clone();
-                                move |row: &String| {
-                                    list.slice()
-                                        .iter()
-                                        .position(|l| l.as_str() == row)
-                                        .unwrap_or(list.slice().len())
-                                }
-                            },
-                            {
-                                let list = self.list.clone();
-                                move |row: &mut String, index: usize| {
-                                    if let Some(element) = list.slice().get(index) {
-                                        row.clear();
-                                        row.push_str(element.as_str());
+                    if let Some(window_id) = self.open_window.take() {
+                        ctx.submit_command(CLOSE_WINDOW.to(Target::Window(window_id)));
+                    } else {
+                        self.open_window = Some(ctx.new_sub_window(
+                            WindowConfig::default()
+                                .show_titlebar(false)
+                                .resizable(false)
+                                .transparent(true)
+                                .window_size(Size::new(
+                                    width,
+                                    25.0 * self.list.slice().len().min(8) as f64 + 2.0,
+                                ))
+                                .set_position(ctx.to_window(Point::new(0.0, height - 1.0)))
+                                .set_level(WindowLevel::DropDown(ctx.window().clone())),
+                            drop_down(&self.list).lens(Identity.map(
+                                {
+                                    let list = self.list.clone();
+                                    move |row: &String| {
+                                        list.slice()
+                                            .iter()
+                                            .position(|l| l.as_str() == row)
+                                            .unwrap_or(list.slice().len())
                                     }
-                                }
-                            },
-                        )),
-                        data.clone(),
-                        env.clone(),
-                    );
+                                },
+                                {
+                                    let list = self.list.clone();
+                                    move |row: &mut String, index: usize| {
+                                        if let Some(element) = list.slice().get(index) {
+                                            row.clear();
+                                            row.push_str(element.as_str());
+                                        }
+                                    }
+                                },
+                            )),
+                            data.clone(),
+                            env.clone(),
+                        ));
+                    }
                 }
             }
             Event::MouseMove(event) => {
@@ -203,6 +213,9 @@ impl<W: Widget<String>, L: ComboList> Widget<String> for OnClick<W, L> {
     }
 
     fn update(&mut self, ctx: &mut UpdateCtx, old_data: &String, data: &String, env: &Env) {
+        if old_data != data {
+            self.open_window = None;
+        }
         self.widget.update(ctx, old_data, data, env)
     }
 
@@ -225,6 +238,7 @@ pub fn custom_user_string(list: impl ComboList) -> impl Widget<String> {
     Pod(druid::WidgetPod::new(ComboBox(OnClick {
         widget: TextBox::new(),
         list,
+        open_window: None,
     })))
 }
 
@@ -232,14 +246,56 @@ pub fn static_list(list: &'static [&'static str]) -> impl Widget<usize> {
     dynamic_list(list)
 }
 
+struct DropdownToggleController {
+    open_window: Rc<Cell<Option<WindowId>>>,
+}
+
+impl<W: Widget<usize>> Controller<usize, W> for DropdownToggleController {
+    fn event(
+        &mut self,
+        child: &mut W,
+        ctx: &mut EventCtx,
+        event: &Event,
+        data: &mut usize,
+        env: &Env,
+    ) {
+        // Intercept MouseDown to close dropdown if one is open
+        if let Event::MouseDown(mouse) = event {
+            if mouse.button == druid::MouseButton::Left {
+                if let Some(window_id) = self.open_window.take() {
+                    ctx.submit_command(CLOSE_WINDOW.to(Target::Window(window_id)));
+                    return; // Don't let button process this click
+                }
+            }
+        }
+        child.event(ctx, event, data, env);
+    }
+
+    fn update(
+        &mut self,
+        child: &mut W,
+        ctx: &mut UpdateCtx,
+        old_data: &usize,
+        data: &usize,
+        env: &Env,
+    ) {
+        if old_data != data {
+            self.open_window.set(None);
+        }
+        child.update(ctx, old_data, data, env)
+    }
+}
+
 pub fn dynamic_list(list: impl ComboList) -> impl Widget<usize> {
+    let open_window: Rc<Cell<Option<WindowId>>> = Rc::new(Cell::new(None));
+    let open_window_clone = open_window.clone();
     ComboBox(
         Button::new({
             let list = list.clone();
             move |&index: &usize, _: &_| list.slice()[index].to_arc_str()
         })
         .on_click(move |ctx, &mut index: &mut usize, env| {
-            ctx.new_sub_window(
+            let window_id = ctx.new_sub_window(
                 WindowConfig::default()
                     .show_titlebar(false)
                     .resizable(false)
@@ -254,12 +310,14 @@ pub fn dynamic_list(list: impl ComboList) -> impl Widget<usize> {
                 index,
                 env.clone(),
             );
+            open_window_clone.set(Some(window_id));
         })
         .env_scope(|env, _| {
             env.set(theme::BUTTON_BORDER_RADIUS, 0.0);
             env.set(theme::BUTTON_LIGHT, Color::grey8(0x10));
             env.set(theme::BUTTON_DARK, Color::grey8(0x10));
-        }),
+        })
+        .controller(DropdownToggleController { open_window }),
     )
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,9 @@ mod settings_table;
 mod timer_form;
 mod window_settings_editor;
 
+#[cfg(feature = "auto-splitting")]
+mod autosplitter_editor;
+
 mod software_renderer;
 // mod piet_renderer;
 
@@ -68,6 +71,8 @@ pub struct MainState {
     layout_editor: Option<OpenWindow<layout_editor::State>>,
     window_settings_editor: Option<OpenWindow<window_settings_editor::State>>,
     hotkeys_editor: Option<OpenWindow<hotkeys_editor::State>>,
+    #[cfg(feature = "auto-splitting")]
+    autosplitter_editor: Option<OpenWindow<autosplitter_editor::State>>,
     image_cache: Rc<RefCell<ImageCache>>,
     mouse_pass_through: bool,
 }
@@ -123,6 +128,8 @@ impl MainState {
             layout_editor: None,
             window_settings_editor: None,
             hotkeys_editor: None,
+            #[cfg(feature = "auto-splitting")]
+            autosplitter_editor: None,
             image_cache: Rc::new(RefCell::new(ImageCache::new())),
             mouse_pass_through: false,
         }
@@ -186,6 +193,24 @@ impl Lens<MainState, hotkeys_editor::State> for HotkeysEditorLens {
         f: F,
     ) -> V {
         f(&mut data.hotkeys_editor.as_mut().unwrap().state)
+    }
+}
+
+#[cfg(feature = "auto-splitting")]
+struct AutoSplitterEditorLens;
+
+#[cfg(feature = "auto-splitting")]
+impl Lens<MainState, autosplitter_editor::State> for AutoSplitterEditorLens {
+    fn with<V, F: FnOnce(&autosplitter_editor::State) -> V>(&self, data: &MainState, f: F) -> V {
+        f(&data.autosplitter_editor.as_ref().unwrap().state)
+    }
+
+    fn with_mut<V, F: FnOnce(&mut autosplitter_editor::State) -> V>(
+        &self,
+        data: &mut MainState,
+        f: F,
+    ) -> V {
+        f(&mut data.autosplitter_editor.as_mut().unwrap().state)
     }
 }
 

--- a/src/timer_form.rs
+++ b/src/timer_form.rs
@@ -14,6 +14,8 @@ use livesplit_core::{LayoutEditor, RunEditor, TimerPhase, TimingMethod};
 #[cfg(not(target_os = "macos"))]
 use native_dialog::MessageType;
 
+#[cfg(feature = "auto-splitting")]
+use crate::{autosplitter_editor, AutoSplitterEditorLens};
 use crate::{
     config::or_show_error,
     consts::{
@@ -116,6 +118,9 @@ const CONTEXT_MENU_SET_TIMING_METHOD: Selector<TimingMethod> =
 const CONTEXT_MENU_EDIT_WINDOW_SETTINGS: Selector =
     Selector::new("context-menu-edit-window-settings");
 const CONTEXT_MENU_EDIT_HOTKEYS: Selector = Selector::new("context-menu-edit-hotkeys");
+#[cfg(feature = "auto-splitting")]
+const CONTEXT_MENU_EDIT_AUTOSPLITTER_SETTINGS: Selector =
+    Selector::new("context-menu-edit-autosplitter-settings");
 
 impl<T: Widget<MainState>> Widget<MainState> for WithMenu<T> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut MainState, env: &Env) {
@@ -312,6 +317,13 @@ impl<T: Widget<MainState>> Widget<MainState> for WithMenu<T> {
                                     CONTEXT_MENU_SET_INTENT.with(Intent::OPEN_AUTO_SPLITTER),
                                 ),
                             )
+                            .entry(
+                                #[cfg(feature = "auto-splitting")]
+                                MenuItem::new("Edit Auto-splitter Settings...")
+                                    .command(CONTEXT_MENU_EDIT_AUTOSPLITTER_SETTINGS),
+                                #[cfg(not(feature = "auto-splitting"))]
+                                MenuItem::new("Auto-splitter settings unavailable").enabled(false),
+                            )
                             .separator()
                             .entry(control_menu)
                             .entry(compare_against)
@@ -498,7 +510,25 @@ impl<T: Widget<MainState>> Widget<MainState> for WithMenu<T> {
                         id: window_id,
                         state: hotkeys_editor::State::new(config),
                     });
-                } else if let Some(intent) = command.get(CONTEXT_MENU_SET_INTENT) {
+                }
+                #[cfg(feature = "auto-splitting")]
+                if command.is(CONTEXT_MENU_EDIT_AUTOSPLITTER_SETTINGS) {
+                    let window = WindowDesc::new(
+                        autosplitter_editor::root_widget().lens(AutoSplitterEditorLens),
+                    )
+                    .title("Auto-splitter Settings")
+                    .with_min_size((550.0, 400.0))
+                    .window_size((550.0, 450.0))
+                    .set_level(WindowLevel::AppWindow)
+                    .set_always_on_top(true);
+                    let window_id = window.id;
+                    ctx.new_window(window);
+                    data.autosplitter_editor = Some(OpenWindow {
+                        id: window_id,
+                        state: autosplitter_editor::State::new(data.auto_splitter.clone()),
+                    });
+                }
+                if let Some(intent) = command.get(CONTEXT_MENU_SET_INTENT) {
                     self.intent = *intent;
                 } else if let Some((intent, path)) = command.get(CONTEXT_MENU_SET_INTENT_WITH_PATH)
                 {
@@ -990,6 +1020,14 @@ impl AppDelegate<MainState> for WindowManagement {
                         .set_mouse_pass_through_while_running(mouse_pass_through_while_running);
                 }
                 data.window_settings_editor = None;
+                return;
+            }
+        }
+
+        #[cfg(feature = "auto-splitting")]
+        if let Some(window) = &data.autosplitter_editor {
+            if id == window.id {
+                data.autosplitter_editor = None;
                 return;
             }
         }

--- a/src/timer_form.rs
+++ b/src/timer_form.rs
@@ -137,11 +137,17 @@ impl<T: Widget<MainState>> Widget<MainState> for WithMenu<T> {
                 }
             }
             Event::MouseUp(event) => {
+                #[cfg(feature = "auto-splitting")]
+                let autosplitter_editor_is_none = data.autosplitter_editor.is_none();
+                #[cfg(not(feature = "auto-splitting"))]
+                let autosplitter_editor_is_none = true;
+
                 if (event.button.is_right() || (event.button.is_left() && event.mods.ctrl()))
                     && data.run_editor.is_none()
                     && data.layout_editor.is_none()
                     && data.window_settings_editor.is_none()
                     && data.hotkeys_editor.is_none()
+                    && autosplitter_editor_is_none
                 {
                     let mut compare_against = Menu::new("Compare Against");
 
@@ -1027,6 +1033,9 @@ impl AppDelegate<MainState> for WindowManagement {
         #[cfg(feature = "auto-splitting")]
         if let Some(window) = &data.autosplitter_editor {
             if id == window.id {
+                if !window.state.closed_with_ok {
+                    window.state.revert_settings();
+                }
                 data.autosplitter_editor = None;
                 return;
             }


### PR DESCRIPTION
Added a menu option for editing autosplitter settings. The window supports all of the types that are currently available for autosplitter settings (Title, Bool, Choice, FileSelect).  Autosplitter settings are saved when splits are saved. 

I have tested a few different autosplitters on Linux (kubuntu 25.10) and Windows 11. I am unable to test Mac, however the Github Actions build passed. 

<img width="244" height="257" alt="image" src="https://github.com/user-attachments/assets/f3dc2f82-10b4-4884-9849-64a43bce2e29" />

<img width="707" height="763" alt="image" src="https://github.com/user-attachments/assets/98867bfc-37f6-4098-9263-7ac1e41eb0d7" />

____________________________

Also fixed are a few UI jank issues:

* All platforms: Clicking a combobox a second time will close the combobox without changing the current selection. 
* All platforms: Clicking a color picker a second time will close the color picker dialog, fixes https://github.com/AlexKnauth/livesplit-one-druid/issues/36 
* Windows: The color picker now appears directly underneath the color button instead of covering it: 
<img width="533" height="750" alt="image" src="https://github.com/user-attachments/assets/3f456e65-d526-4a87-b4c7-425561de5a58" />


Linux: I was unable to fix the issue where dialogs always appear in the top left of the window, this seems like a Druid + Wayland issue that is beyond my abilities. Tooltips on the autosplitter settings also have a titlebar, this seems to also be a Wayland problem. Works fine on Windows. 