### PR TITLE
Allow resizing window as small as 15px

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -23,7 +23,7 @@ use std::{
     sync::Arc,
 };
 
-use crate::{cli, server, timer_form, LayoutData, MainState};
+use crate::{cli, consts::TIMER_MIN_SIZE, server, timer_form, LayoutData, MainState};
 
 #[derive(Default, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
@@ -614,7 +614,7 @@ impl Config {
     pub fn build_window(&self) -> WindowDesc<MainState> {
         let w = WindowDesc::new(timer_form::root_widget())
             .title("LiveSplit One")
-            .with_min_size((50.0, 50.0))
+            .with_min_size((TIMER_MIN_SIZE, TIMER_MIN_SIZE))
             .window_size((self.window.width, self.window.height))
             .show_titlebar(false)
             .transparent(true)

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,6 +1,6 @@
 use druid::{theme, Color, Env, FontDescriptor, FontFamily, FontWeight};
 
-pub const TIMER_MIN_SIZE: f64 = 50.0;
+pub const TIMER_MIN_SIZE: f64 = 15.0;
 
 pub const ICON_SIZE: f64 = 140.0;
 pub const MARGIN: f64 = 20.0;

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,5 +1,7 @@
 use druid::{theme, Color, Env, FontDescriptor, FontFamily, FontWeight};
 
+pub const TIMER_MIN_SIZE: f64 = 50.0;
+
 pub const ICON_SIZE: f64 = 140.0;
 pub const MARGIN: f64 = 20.0;
 pub const SPACING: f64 = 16.0;

--- a/src/timer_form.rs
+++ b/src/timer_form.rs
@@ -14,6 +14,8 @@ use druid::{
 };
 use livesplit_core::{LayoutEditor, RunEditor, TimerPhase, TimingMethod};
 
+#[cfg(target_os = "linux")]
+use crate::consts::TIMER_MIN_SIZE;
 #[cfg(feature = "auto-splitting")]
 use crate::{autosplitter_editor, AutoSplitterEditorLens};
 use crate::{
@@ -1109,24 +1111,24 @@ impl<T, W: Widget<T>> Controller<T, W> for WindowInteractionController {
 
                         match edge {
                             ResizeEdge::Left | ResizeEdge::TopLeft | ResizeEdge::BottomLeft => {
-                                new_size.width = (init_size.width - dx).max(50.0);
+                                new_size.width = (init_size.width - dx).max(TIMER_MIN_SIZE);
                                 new_pos.x = init_win.x + (init_size.width - new_size.width);
                             }
                             ResizeEdge::Right | ResizeEdge::TopRight | ResizeEdge::BottomRight => {
-                                new_size.width = (init_size.width + dx).max(50.0);
+                                new_size.width = (init_size.width + dx).max(TIMER_MIN_SIZE);
                             }
                             _ => {}
                         }
 
                         match edge {
                             ResizeEdge::Top | ResizeEdge::TopLeft | ResizeEdge::TopRight => {
-                                new_size.height = (init_size.height - dy).max(50.0);
+                                new_size.height = (init_size.height - dy).max(TIMER_MIN_SIZE);
                                 new_pos.y = init_win.y + (init_size.height - new_size.height);
                             }
                             ResizeEdge::Bottom
                             | ResizeEdge::BottomLeft
                             | ResizeEdge::BottomRight => {
-                                new_size.height = (init_size.height + dy).max(50.0);
+                                new_size.height = (init_size.height + dy).max(TIMER_MIN_SIZE);
                             }
                             _ => {}
                         }


### PR DESCRIPTION
Resolves #51 as far as I want to take it given `RESIZE_BORDER` constraints. I wouldn't want 1px, but 15px is fine. The `RESIZE_BORDER` is 5px, and there still needs to be room in between the resize borders for dragging to move the window, so I don't want it any less than 3 times the `RESIZE_BORDER`.