### PR TITLE
Distinguish "Failed writing the file" errors

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -431,7 +431,8 @@ impl Config {
             timer.run_auto_splitter_settings_map_store(runtime.settings_map().unwrap_or_default());
             let mut buf = String::new();
             save_timer(timer, &mut buf).context("Failed saving the splits.")?;
-            fs::write(path, &buf).context(format!("Failed writing the splits file to {:?}.", path))?;
+            fs::write(path, &buf)
+                .context(format!("Failed writing the splits file to {:?}.", path))?;
             timer.mark_as_unmodified();
 
             self.splits.remove_from_history();
@@ -517,7 +518,8 @@ impl Config {
             settings
                 .write_json(&mut buf)
                 .context("Failed saving the layout.")?;
-            fs::write(path, &buf).context(format!("Failed writing the layout file to {:?}.", path))?;
+            fs::write(path, &buf)
+                .context(format!("Failed writing the layout file to {:?}.", path))?;
         }
         Ok(())
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -431,7 +431,7 @@ impl Config {
             timer.run_auto_splitter_settings_map_store(runtime.settings_map().unwrap_or_default());
             let mut buf = String::new();
             save_timer(timer, &mut buf).context("Failed saving the splits.")?;
-            fs::write(path, &buf).context("Failed writing the file.")?;
+            fs::write(path, &buf).context(format!("Failed writing the splits file to {:?}.", path))?;
             timer.mark_as_unmodified();
 
             self.splits.remove_from_history();
@@ -454,7 +454,7 @@ impl Config {
         timer.run_auto_splitter_settings_map_store(runtime.settings_map().unwrap_or_default());
         let mut buf = String::new();
         save_timer(timer, &mut buf).context("Failed saving the splits.")?;
-        fs::write(&path, &buf).context("Failed writing the file.")?;
+        fs::write(&path, &buf).context(format!("Failed writing the splits file to {:?}.", path))?;
         timer.mark_as_unmodified();
 
         if !self.splits.can_save {
@@ -517,7 +517,7 @@ impl Config {
             settings
                 .write_json(&mut buf)
                 .context("Failed saving the layout.")?;
-            fs::write(path, &buf).context("Failed writing the file.")?;
+            fs::write(path, &buf).context(format!("Failed writing the layout file to {:?}.", path))?;
         }
         Ok(())
     }
@@ -532,7 +532,7 @@ impl Config {
         settings
             .write_json(&mut buf)
             .context("Failed saving the layout.")?;
-        fs::write(&path, &buf).context("Failed writing the file.")?;
+        fs::write(&path, &buf).context(format!("Failed writing the layout file to {:?}.", path))?;
 
         timer.layout_path_changed(path.to_str());
 


### PR DESCRIPTION
> what does this error from livesplit (druid) mean when saving splits?

> I haven't seen that error message before, so I don't really know.
> However, I can go through the source code and find all the places that an error message like that could come from, of which there are 4 places all within `config.rs`:
> - in `save_splits`, line 434 when `fs::write` fails
> - in `save_splits_as`, line 457 when `fs::write` fails
> - in `save_layout`, line 520 when `fs::write` fails
> - in `save_layout_as`, line 535 when `fs::write` fails
> And according to the documentation of `fs::write`:
> > this function may fail if the full directory path does not exist