### PR TITLE
livesplit-core: auto-splitter-settings-in-splits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,7 +2375,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 [[package]]
 name = "livesplit-auto-splitting"
 version = "0.1.0"
-source = "git+https://github.com/AlexKnauth/livesplit-core?branch=dev#9cfc24902053e3c511ec77f02bcea53f835a5e56"
+source = "git+https://github.com/AlexKnauth/livesplit-core?branch=dev#b96c4bf26b020a6f421f06a4a9ebb36cfb868782"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2398,7 +2398,7 @@ dependencies = [
 [[package]]
 name = "livesplit-core"
 version = "0.13.0"
-source = "git+https://github.com/AlexKnauth/livesplit-core?branch=dev#9cfc24902053e3c511ec77f02bcea53f835a5e56"
+source = "git+https://github.com/AlexKnauth/livesplit-core?branch=dev#b96c4bf26b020a6f421f06a4a9ebb36cfb868782"
 dependencies = [
  "arc-swap",
  "base64-simd",
@@ -2435,7 +2435,7 @@ dependencies = [
 [[package]]
 name = "livesplit-hotkey"
 version = "0.8.1"
-source = "git+https://github.com/AlexKnauth/livesplit-core?branch=dev#9cfc24902053e3c511ec77f02bcea53f835a5e56"
+source = "git+https://github.com/AlexKnauth/livesplit-core?branch=dev#b96c4bf26b020a6f421f06a4a9ebb36cfb868782"
 dependencies = [
  "bitflags 2.10.0",
  "cfg-if",
@@ -2476,7 +2476,7 @@ dependencies = [
 [[package]]
 name = "livesplit-title-abbreviations"
 version = "0.3.0"
-source = "git+https://github.com/AlexKnauth/livesplit-core?branch=dev#9cfc24902053e3c511ec77f02bcea53f835a5e56"
+source = "git+https://github.com/AlexKnauth/livesplit-core?branch=dev#b96c4bf26b020a6f421f06a4a9ebb36cfb868782"
 
 [[package]]
 name = "log"
@@ -3949,7 +3949,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "287f59010008f0d7cf5e3b03196d666c1acc46c8d3e9cf34c28a1a7157601e72"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -5105,7 +5105,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,7 +2375,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 [[package]]
 name = "livesplit-auto-splitting"
 version = "0.1.0"
-source = "git+https://github.com/AlexKnauth/livesplit-core?branch=dev#dcd79aa8c70c5368d8151281fc473cd62de8b89d"
+source = "git+https://github.com/AlexKnauth/livesplit-core?branch=dev#9cfc24902053e3c511ec77f02bcea53f835a5e56"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2398,7 +2398,7 @@ dependencies = [
 [[package]]
 name = "livesplit-core"
 version = "0.13.0"
-source = "git+https://github.com/AlexKnauth/livesplit-core?branch=dev#dcd79aa8c70c5368d8151281fc473cd62de8b89d"
+source = "git+https://github.com/AlexKnauth/livesplit-core?branch=dev#9cfc24902053e3c511ec77f02bcea53f835a5e56"
 dependencies = [
  "arc-swap",
  "base64-simd",
@@ -2435,7 +2435,7 @@ dependencies = [
 [[package]]
 name = "livesplit-hotkey"
 version = "0.8.1"
-source = "git+https://github.com/AlexKnauth/livesplit-core?branch=dev#dcd79aa8c70c5368d8151281fc473cd62de8b89d"
+source = "git+https://github.com/AlexKnauth/livesplit-core?branch=dev#9cfc24902053e3c511ec77f02bcea53f835a5e56"
 dependencies = [
  "bitflags 2.10.0",
  "cfg-if",
@@ -2476,7 +2476,7 @@ dependencies = [
 [[package]]
 name = "livesplit-title-abbreviations"
 version = "0.3.0"
-source = "git+https://github.com/AlexKnauth/livesplit-core?branch=dev#dcd79aa8c70c5368d8151281fc473cd62de8b89d"
+source = "git+https://github.com/AlexKnauth/livesplit-core?branch=dev#9cfc24902053e3c511ec77f02bcea53f835a5e56"
 
 [[package]]
 name = "log"
@@ -3949,7 +3949,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "287f59010008f0d7cf5e3b03196d666c1acc46c8d3e9cf34c28a1a7157601e72"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -5105,7 +5105,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,6 +294,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64-simd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,7 +315,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -329,9 +341,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bitstream-io"
@@ -451,7 +463,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -670,10 +682,10 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad36507aeb7e16159dfe68db81ccc27571c3ccd4b76fb2fb72fc59e7a4b1b64c"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block",
  "cocoa-foundation",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "foreign-types",
  "libc",
@@ -686,9 +698,9 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81411967c50ee9a1fc11365f8c585f863a22a9697c89239c452292c40ba79b0d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "objc",
 ]
@@ -717,6 +729,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -737,8 +759,8 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
- "bitflags 2.10.0",
- "core-foundation",
+ "bitflags 2.13.1",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -750,8 +772,8 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.10.0",
- "core-foundation",
+ "bitflags 2.13.1",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -761,7 +783,7 @@ version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a593227b66cbd4007b2a050dfdd9e1d1318311409c8d600dc82ba1b15ca9c130"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "foreign-types",
  "libc",
@@ -782,7 +804,7 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da46a9d5a8905cc538a4a5bceb6a4510de7a51049c5588c0114efce102bcbbe8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "fontdb",
  "hashbrown 0.14.5",
  "libm",
@@ -1115,7 +1137,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block2",
  "libc",
  "objc2",
@@ -1688,8 +1710,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1711,9 +1735,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1782,7 +1808,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -1893,6 +1919,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1947,12 +1992,113 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "http"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "system-configuration",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2356,7 +2502,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "libc",
 ]
 
@@ -2437,7 +2583,7 @@ name = "livesplit-hotkey"
 version = "0.8.1"
 source = "git+https://github.com/AlexKnauth/livesplit-core?branch=dev#b96c4bf26b020a6f421f06a4a9ebb36cfb868782"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "crossbeam-channel",
  "evdev",
@@ -2469,6 +2615,9 @@ dependencies = [
  "mimalloc",
  "native-dialog",
  "once_cell",
+ "percent-encoding",
+ "quick-xml",
+ "reqwest",
  "serde",
  "serde_yaml",
 ]
@@ -2495,6 +2644,12 @@ checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
 dependencies = [
  "imgref",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mach"
@@ -2660,7 +2815,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2672,7 +2827,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2820,7 +2975,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block2",
  "libc",
  "objc2",
@@ -2842,7 +2997,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -2853,7 +3008,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -2864,7 +3019,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block2",
  "dispatch2",
  "libc",
@@ -2877,7 +3032,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -2900,7 +3055,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -2912,7 +3067,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -2931,7 +3086,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block2",
  "libc",
  "objc2",
@@ -2954,7 +3109,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2965,7 +3120,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -3013,6 +3168,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "option-ext"
@@ -3145,7 +3306,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5c63b3187daffba0670cdca92d374fe569693e8b6cbbd76fc320cc7c68d7728"
 dependencies = [
  "associative-cache",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "core-graphics",
  "core-text",
@@ -3205,7 +3366,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -3390,6 +3551,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
+name = "quick-xml"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b1177fdf999d2321d3fb46ff47159d9c1fb9ad66a4879f8c50a0b504615e9b"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3461,6 +3688,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "rangemap"
@@ -3632,10 +3868,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "roxmltree"
@@ -3676,7 +3967,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3694,6 +3985,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3705,7 +4043,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfb9cf8877777222e4a3bc7eb247e398b56baba500c38c1c46842431adc8b55c"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "bytemuck",
  "libm",
  "smallvec",
@@ -3723,10 +4061,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "self_cell"
@@ -3755,9 +4125,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -3765,22 +4135,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3812,6 +4182,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3984,6 +4366,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swash"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4014,6 +4402,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -4049,6 +4457,27 @@ dependencies = [
  "objc2-io-kit",
  "rayon",
  "windows",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -4251,6 +4680,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "libc",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4335,6 +4788,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.13.1",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4387,6 +4885,12 @@ dependencies = [
  "tracing-subscriber",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "ttf-parser"
@@ -4545,6 +5049,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4634,6 +5144,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4659,6 +5178,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -4709,7 +5242,7 @@ version = "0.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4439c5eee9df71ee0c6efb37f63b1fcb1fec38f85f5142c54e7ed05d33091a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "hashbrown 0.17.1",
  "indexmap",
  "semver",
@@ -4735,7 +5268,7 @@ checksum = "8a83ef84ac8bab735c89e27b0268b0586099fbe81281ae45be2b8e4f407b2daa"
 dependencies = [
  "addr2line 0.26.1",
  "async-trait",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "bumpalo",
  "cc",
  "cfg-if",
@@ -4947,7 +5480,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ada06667b7948892703fcc9f0b9b337c2e78c334d74d4fa62e2f75f07fbb3659"
 dependencies = [
  "anyhow",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "heck 0.5.0",
  "indexmap",
  "wit-parser",
@@ -4960,7 +5493,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd8e9db77f7b60f4c5f6f72847f55eb646ed7ed2f68e362559ee07dc543fb408"
 dependencies = [
  "async-trait",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "bytes",
  "cap-fs-ext",
  "cap-net-ext",
@@ -5016,6 +5549,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5049,7 +5592,7 @@ version = "45.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4aca130e25a57e29bbb541441b6e261970a8469580bffebe904d96f0df67e41d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "thiserror 2.0.18",
  "tracing",
  "wasmtime",
@@ -5217,6 +5760,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5241,6 +5795,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5428,7 +5991,7 @@ version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "windows-sys 0.59.0",
 ]
 
@@ -5591,6 +6154,12 @@ dependencies = [
  "syn 2.0.114",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,13 +25,29 @@ anyhow = "1.0.93"
 fontdb = "0.16.2"
 clap = { version = "4.5.20", features = ["derive"] }
 futures = "0.3.31"
+percent-encoding = { version = "2.3.2" , optional = true }
+quick-xml = { version = "0.42.0", features = [
+    "serialize",
+    "overlapped-lists",
+], optional = true }
+reqwest = { version = "0.12.1", features = [
+    "blocking",
+    "http2",
+    "macos-system-configuration",
+    "rustls-tls-native-roots",
+], default-features = false, optional = true }
 
 [build-dependencies]
 embed-resource = "3.0.1"
 
 [features]
 default = ["auto-splitting"]
-auto-splitting = ["livesplit-core/auto-splitting"]
+auto-splitting = [
+    "livesplit-core/auto-splitting",
+    "dep:percent-encoding",
+    "dep:quick-xml",
+    "dep:reqwest",
+]
 
 [profile.max-opt]
 inherits = "release"

--- a/src/auto_splitters.rs
+++ b/src/auto_splitters.rs
@@ -1,0 +1,264 @@
+use anyhow::{format_err, Context, Error, Result};
+use livesplit_core::util::PopulateString;
+use log::{error, info, warn};
+use quick_xml::de;
+use reqwest::{blocking::Client, Url};
+use serde::Deserialize;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    str,
+    sync::OnceLock,
+};
+
+use crate::config::get_config_folder;
+
+const LIST_FILE_NAME: &str = "LiveSplit.AutoSplitters.xml";
+
+pub static LIST: OnceLock<List> = OnceLock::new();
+
+pub fn get_list() -> &'static List {
+    static EMPTY: List = List::empty();
+
+    LIST.get().unwrap_or(&EMPTY)
+}
+
+pub fn get_downloader() -> &'static Downloader {
+    static DOWNLOADER: OnceLock<Downloader> = OnceLock::new();
+
+    DOWNLOADER.get_or_init(Downloader::new)
+}
+
+pub fn get_path() -> Option<&'static Path> {
+    static PATH: OnceLock<PathBuf> = OnceLock::new();
+
+    let config_folder = get_config_folder()?;
+    Some(PATH.get_or_init(|| config_folder.join("auto-splitters")))
+}
+
+pub struct Downloader {
+    client: Client,
+}
+
+pub struct List {
+    inner: ListInner,
+    source: String,
+}
+
+#[derive(Deserialize)]
+struct ListInner {
+    #[serde(rename = "AutoSplitter")]
+    auto_splitters: Vec<AutoSplitter>,
+}
+
+#[derive(Deserialize)]
+pub struct AutoSplitter {
+    #[serde(rename = "Games")]
+    games: Games,
+    #[serde(rename = "URLs")]
+    urls: Urls,
+    // #[serde(rename = "Type")]
+    // module_type: String,
+    #[serde(rename = "ScriptType")]
+    script_type: Option<String>,
+    #[serde(rename = "Description")]
+    pub description: String,
+    #[serde(rename = "Website")]
+    pub website: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct Games {
+    #[serde(rename = "Game")]
+    games: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct Urls {
+    #[serde(rename = "URL")]
+    urls: Vec<String>,
+}
+
+impl List {
+    pub const fn empty() -> Self {
+        Self {
+            inner: ListInner {
+                auto_splitters: Vec::new(),
+            },
+            source: String::new(),
+        }
+    }
+
+    pub fn save_to_disk(&self, folder: &Path) -> Result<()> {
+        fs::write(folder.join(LIST_FILE_NAME), &self.source).map_err(Into::into)
+    }
+
+    pub fn get_website_for_game(&self, game_name: &str) -> Option<&str> {
+        self.get_for_game(game_name)?.website.as_deref()
+    }
+
+    pub fn get_for_game(&self, game_name: &str) -> Option<&AutoSplitter> {
+        self.inner
+            .auto_splitters
+            .iter()
+            .find(|x| x.games.games.iter().any(|g| g == game_name))
+    }
+}
+
+impl Downloader {
+    pub fn new() -> Self {
+        Self {
+            client: Client::builder()
+                .use_rustls_tls()
+                .http2_prior_knowledge()
+                .build()
+                .unwrap(),
+        }
+    }
+
+    pub fn download_list(&self, folder: &Path) -> Result<List, [Error; 2]> {
+        let from_github_error = match get_list_from_github(&self.client) {
+            Ok(list) => return Ok(list),
+            Err(e) => e,
+        };
+
+        let from_file_error = match get_list_from_file(folder) {
+            Ok(list) => {
+                warn!("Failed downloading the auto splitters list from GitHub. Using the cached version. Error: {from_github_error:?}");
+                return Ok(list);
+            }
+            Err(e) => e,
+        };
+
+        Err([from_github_error, from_file_error])
+    }
+
+    pub fn download_for_game(
+        &self,
+        list: &List,
+        game_name: &str,
+        folder: Option<&Path>,
+    ) -> Option<PathBuf> {
+        self.download(list.get_for_game(game_name)?, folder?)
+    }
+
+    pub fn download(&self, auto_splitter: &AutoSplitter, folder: &Path) -> Option<PathBuf> {
+        let mut file_paths = Vec::new();
+
+        for url in &auto_splitter.urls.urls {
+            if let Err(e) = self
+                .download_file(url, folder, &mut file_paths)
+                .with_context(|| format_err!("Failed downloading `{url}`."))
+            {
+                error!("{e:#?}");
+            }
+        }
+
+        file_paths
+            .into_iter()
+            .find(|path| path.extension().is_some_and(|e| e == "wasm"))
+    }
+
+    fn download_file(&self, url: &str, folder: &Path, file_paths: &mut Vec<PathBuf>) -> Result<()> {
+        let url = Url::parse(url).context("Failed parsing the URL.")?;
+
+        let file_name = url
+            .path_segments()
+            .and_then(|mut s| s.next_back())
+            .context("There is no file name in the URL.")?;
+
+        let file_name = percent_encoding::percent_decode_str(file_name).decode_utf8_lossy();
+        let file_path = folder.join(file_name.as_str());
+
+        let bytes = self
+            .client
+            .get(url)
+            .send()
+            .context("Failed sending the request.")?
+            .error_for_status()
+            .context("The response is unsuccessful.")?
+            .bytes()
+            .context("Failed receiving the response.")?;
+
+        fs::write(&file_path, bytes).context("Failed writing the file.")?;
+
+        file_paths.push(file_path);
+
+        Ok(())
+    }
+}
+
+impl AutoSplitter {
+    pub fn is_using_auto_splitting_runtime(&self) -> bool {
+        self.script_type
+            .as_ref()
+            .is_some_and(|t| t == "AutoSplittingRuntime")
+    }
+}
+
+fn get_list_from_github(client: &Client) -> Result<List> {
+    let url = "https://raw.githubusercontent.com/LiveSplit/LiveSplit.AutoSplitters/master/LiveSplit.AutoSplitters.xml";
+
+    let source = client
+        .get(url)
+        .send()
+        .context("Failed sending the request.")?
+        .error_for_status()
+        .context("The response was unsuccessful.")?
+        .text()
+        .context("Failed receiving the body as text.")?;
+
+    Ok(List {
+        inner: de::from_str(&source).context("Failed parsing the list.")?,
+        source,
+    })
+}
+
+fn get_list_from_file(folder: &Path) -> Result<List> {
+    let source =
+        fs::read_to_string(folder.join(LIST_FILE_NAME)).context("Failed reading the file.")?;
+
+    Ok(List {
+        inner: de::from_str(&source).context("Failed parsing the list.")?,
+        source,
+    })
+}
+
+pub fn set_up() -> Option<()> {
+    let auto_splitters_path = get_path()?;
+
+    if let Err(e) = fs::create_dir_all(auto_splitters_path)
+        .context("Failed creating the auto splitters folder.")
+    {
+        error!("{:?}", e);
+        return None;
+    }
+
+    match get_downloader().download_list(get_config_folder()?) {
+        Ok(list) => {
+            if let Err(e) = list
+                .save_to_disk(auto_splitters_path)
+                .context("Failed saving the list of auto splitters.")
+            {
+                error!("{:?}", e);
+                return None;
+            }
+
+            let _ = LIST.set(list);
+            info!("Auto splitter list loaded.");
+        }
+        Err([from_github, from_file]) => {
+            error!(
+                "{:?}",
+                from_github.context("Failed downloading the list of auto splitters.")
+            );
+            error!(
+                "{:?}",
+                from_file.context("Failed loading the list of auto splitters from the cache.")
+            );
+            return None;
+        }
+    }
+
+    Some(())
+}

--- a/src/auto_splitters.rs
+++ b/src/auto_splitters.rs
@@ -51,7 +51,7 @@ struct ListInner {
     auto_splitters: Vec<AutoSplitter>,
 }
 
-#[derive(Deserialize)]
+#[derive(Clone, Deserialize)]
 pub struct AutoSplitter {
     #[serde(rename = "Games")]
     games: Games,
@@ -67,13 +67,13 @@ pub struct AutoSplitter {
     pub website: Option<String>,
 }
 
-#[derive(Deserialize)]
+#[derive(Clone, Deserialize)]
 struct Games {
     #[serde(rename = "Game")]
     games: Vec<String>,
 }
 
-#[derive(Deserialize)]
+#[derive(Clone, Deserialize)]
 struct Urls {
     #[serde(rename = "URL")]
     urls: Vec<String>,

--- a/src/autosplitter_choice_editor.rs
+++ b/src/autosplitter_choice_editor.rs
@@ -164,6 +164,7 @@ fn settings_editor() -> impl Widget<State> {
 fn settings_widget() -> impl Widget<State> {
     Flex::column()
         .with_child(external_auto_splitter_widget())
+        .with_spacer(BUTTON_SPACING)
         .with_child(use_local_auto_splitter_widget())
         .with_child(local_auto_splitter_path_widget())
 }
@@ -308,11 +309,13 @@ fn local_auto_splitter_path_widget() -> impl Widget<State> {
                             },
                         ])
                         .accept_command(CHOICE_EDITOR_OPEN_AUTO_SPLITTER);
+                    /*
                     let opts = if let Some(p) = s.runtime.loaded_path() {
                         opts.force_starting_directory(p)
                     } else {
                         opts
                     };
+                    */
                     let open_dialog = commands::SHOW_OPEN_PANEL.with(opts);
                     ctx.submit_command(open_dialog);
                 })

--- a/src/autosplitter_choice_editor.rs
+++ b/src/autosplitter_choice_editor.rs
@@ -218,11 +218,20 @@ fn use_local_auto_splitter_widget() -> impl Widget<State> {
 
 fn local_auto_splitter_path_widget() -> impl Widget<State> {
     Flex::row()
+        .with_child(Label::dynamic(|s: &State, _| {
+            s.runtime
+                .loaded_path()
+                .unwrap_or_default()
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string()
+        }))
         .with_spacer(BUTTON_SPACING)
         .with_child(
-            Button::new("Open Auto-splitter").on_click(|ctx, _s: &mut State, _env| {
-                let open_dialog = commands::SHOW_OPEN_PANEL.with(
-                    FileDialogOptions::new()
+            Button::new("Open Auto-splitter")
+                .on_click(|ctx, s: &mut State, _env| {
+                    let opts = FileDialogOptions::new()
                         .title("Open Auto-splitter")
                         .allowed_types(vec![
                             FileSpec {
@@ -234,12 +243,17 @@ fn local_auto_splitter_path_widget() -> impl Widget<State> {
                                 extensions: &["*.*"],
                             },
                         ])
-                        .accept_command(CHOICE_EDITOR_OPEN_AUTO_SPLITTER),
-                );
-                ctx.submit_command(open_dialog);
-            }),
+                        .accept_command(CHOICE_EDITOR_OPEN_AUTO_SPLITTER);
+                    let opts = if let Some(p) = s.runtime.loaded_path() {
+                        opts.force_starting_directory(p)
+                    } else {
+                        opts
+                    };
+                    let open_dialog = commands::SHOW_OPEN_PANEL.with(opts);
+                    ctx.submit_command(open_dialog);
+                })
+                .disabled_if(|s: &State, _| !s.use_local_auto_splitter),
         )
-        .disabled_if(|s: &State, _| !s.use_local_auto_splitter)
 }
 
 fn dialog_buttons() -> impl Widget<State> {

--- a/src/autosplitter_choice_editor.rs
+++ b/src/autosplitter_choice_editor.rs
@@ -22,13 +22,13 @@ use livesplit_core::{
         },
         wasi_path, Runtime,
     },
-    event::CommandSink,
+    event::{CommandSink, TimerQuery},
     SharedTimer, StoredAutoSplitterSettings,
 };
 
 use crate::{
-    combo_box,
-    config::Config,
+    auto_splitters, combo_box,
+    config::{or_show_error, show_error, Config},
     consts::{BUTTON_SPACING, DIALOG_BUTTON_HEIGHT, DIALOG_BUTTON_WIDTH, MARGIN},
 };
 
@@ -82,32 +82,14 @@ impl State {
     pub(crate) fn revert_settings(&self) {
         self.config
             .borrow_mut()
-            .set_use_local_auto_splitter(self.original_use_local_auto_splitter);
-        let settings = self.original_settings.clone().unwrap_or_default();
-        if &self.runtime.loaded_path() == &self.original_loaded_path {
-            self.runtime.set_settings_map(settings);
-        } else {
-            self.runtime.unload().ok();
-            let mut s = StoredAutoSplitterSettings::new();
-            if self.original_use_local_auto_splitter {
-                s.set_script_path(
-                    self.original_loaded_path
-                        .as_ref()
-                        .map(|p| p.to_string_lossy()),
-                );
-            }
-            s.set_settings_map(settings);
-            drop(self.timer.set_auto_splitter_settings(s));
-            if self.original_use_local_auto_splitter {
-                self.runtime.load(self.timer.clone()).ok();
-            } else if let Some(p) = &self.original_loaded_path {
-                self.runtime
-                    .load_from_path(self.timer.clone(), p.to_path_buf())
-                    .ok();
-            } else {
-                self.runtime.load(self.timer.clone()).ok();
-            }
-        }
+            .revert_auto_splitter(
+                &self.timer,
+                &self.runtime,
+                self.original_use_local_auto_splitter,
+                self.original_loaded_path.as_deref(),
+                self.original_settings.clone(),
+            )
+            .ok();
     }
 }
 
@@ -132,8 +114,11 @@ impl<W: Widget<State>> Controller<State, W> for SyncController {
         // Handle file dialog request command
         if let Event::Command(cmd) = event {
             if let Some(file_info) = cmd.get(CHOICE_EDITOR_OPEN_AUTO_SPLITTER) {
-                data.runtime
-                    .load_from_path(data.timer.clone(), file_info.path().to_path_buf());
+                // TODO: pass use_local_auto_splitter
+                data.config
+                    .borrow_mut()
+                    .open_auto_splitter(&data.timer, &data.runtime, file_info.path())
+                    .ok();
 
                 ctx.set_handled();
                 return;
@@ -175,9 +160,41 @@ fn settings_widget() -> impl Widget<State> {
 fn external_auto_splitter_widget() -> impl Widget<State> {
     Flex::row().with_spacer(BUTTON_SPACING).with_child(
         Button::new("Activate")
-            .on_click(|_ctx, s: &mut State, _env| {
+            .on_click(|_ctx, data: &mut State, _env| {
                 // TODO: store the autosplitter to be activated somewhere
-                todo!("Activate")
+                let timer = data.timer.get_timer();
+                let game_name = timer.run().game_name();
+                if let Some(auto_splitter) = auto_splitters::get_list().get_for_game(game_name) {
+                    // TODO: allow an auto_splitter with AutoSplittingRuntime child support
+                    if !auto_splitter.is_using_auto_splitting_runtime() {
+                        show_error(anyhow::Error::msg(
+                            "This game's auto splitter is incompatible with LiveSplit One.",
+                        ));
+                    } else if let Some(auto_splitter_path) = auto_splitters::get_downloader()
+                        .download_for_game(
+                            auto_splitters::get_list(),
+                            game_name,
+                            auto_splitters::get_path(),
+                        )
+                    {
+                        let result = data.config.borrow_mut().open_auto_splitter(
+                            #[cfg(feature = "auto-splitting")]
+                            &data.timer,
+                            #[cfg(feature = "auto-splitting")]
+                            &data.runtime,
+                            &auto_splitter_path,
+                        );
+                        or_show_error(result);
+                    } else {
+                        show_error(anyhow::Error::msg(
+                            "Couldn't download the auto splitter files.",
+                        ));
+                    }
+                } else {
+                    show_error(anyhow::Error::msg(
+                        "No auto splitter available for this game.",
+                    ));
+                }
             })
             .disabled_if(|s: &State, _| s.use_local_auto_splitter),
     )

--- a/src/autosplitter_choice_editor.rs
+++ b/src/autosplitter_choice_editor.rs
@@ -124,10 +124,12 @@ impl<W: Widget<State>> Controller<State, W> for SyncController {
         if let Event::Command(cmd) = event {
             if let Some(file_info) = cmd.get(CHOICE_EDITOR_OPEN_AUTO_SPLITTER) {
                 // TODO: pass use_local_auto_splitter
-                data.config
-                    .borrow_mut()
-                    .open_auto_splitter(&data.timer, &data.runtime, file_info.path())
-                    .ok();
+                let result = data.config.borrow_mut().open_auto_splitter(
+                    &data.timer,
+                    &data.runtime,
+                    file_info.path(),
+                );
+                or_show_error(result);
 
                 ctx.set_handled();
                 return;
@@ -253,9 +255,20 @@ fn use_local_auto_splitter_widget() -> impl Widget<State> {
                     |s: &State| s.use_local_auto_splitter,
                     |s: &mut State, val: bool| {
                         s.use_local_auto_splitter = val;
-                        // TODO: if !val then load externally fixed
-                        // auto splitter if already activated?
-                        // and different from current loaded_path
+                        if !val {
+                            let mut config = s.config.borrow_mut();
+                            if let Some(p) = config.get_game_auto_splitter(&s.game_name) {
+                                if s.runtime.loaded_path().as_deref() != Some(p) {
+                                    // p from the shared borrow of config needs to be copied and dropped
+                                    // before a new mutable borrow of config can be used below
+                                    let p = p.to_path_buf();
+                                    // TODO: pass use_local_auto_splitter
+                                    let result =
+                                        config.open_auto_splitter(&s.timer, &s.runtime, &p);
+                                    or_show_error(result);
+                                }
+                            }
+                        }
                     },
                 ))
                 .center(),

--- a/src/autosplitter_choice_editor.rs
+++ b/src/autosplitter_choice_editor.rs
@@ -103,8 +103,7 @@ fn settings_editor() -> impl Widget<State> {
 }
 
 fn settings_widget() -> impl Widget<State> {
-    Flex::row()
-        .with_spacer(BUTTON_SPACING)
+    Flex::row().with_spacer(BUTTON_SPACING)
 }
 
 fn dialog_buttons() -> impl Widget<State> {

--- a/src/autosplitter_choice_editor.rs
+++ b/src/autosplitter_choice_editor.rs
@@ -9,7 +9,8 @@ use std::{
 use druid::{
     commands,
     lens::Identity,
-    widget::{Button, Controller, Flex, Label, ListIter, Scroll, Switch},
+    text::TextAlignment,
+    widget::{Button, Controller, Flex, Label, LineBreaking, ListIter, Scroll, Switch},
     Data, Env, Event, EventCtx, FileDialogOptions, FileInfo, FileSpec, LensExt, LifeCycle,
     LifeCycleCtx, Selector, Widget, WidgetExt,
 };
@@ -45,6 +46,10 @@ pub struct State {
     #[data(ignore)]
     pub config: Rc<RefCell<Config>>,
     #[data(ignore)]
+    game_name: String,
+    #[data(ignore)]
+    auto_splitter: Option<auto_splitters::AutoSplitter>,
+    #[data(ignore)]
     pub closed_with_ok: bool,
     /// Original use_local_auto_splitter value when the dialog was opened,
     /// used to revert on cancel
@@ -66,6 +71,8 @@ impl State {
     ) -> Self {
         let settings_map = runtime.settings_map();
         let use_local_auto_splitter = config.borrow().get_use_local_auto_splitter();
+        let game_name = timer.get_timer().run().game_name().to_string();
+        let auto_splitter = auto_splitters::get_list().get_for_game(&game_name).cloned();
         Self {
             use_local_auto_splitter,
             original_use_local_auto_splitter: use_local_auto_splitter,
@@ -74,6 +81,8 @@ impl State {
             timer,
             runtime,
             config,
+            game_name,
+            auto_splitter,
             closed_with_ok: false,
         }
     }
@@ -158,46 +167,72 @@ fn settings_widget() -> impl Widget<State> {
 }
 
 fn external_auto_splitter_widget() -> impl Widget<State> {
-    Flex::row().with_spacer(BUTTON_SPACING).with_child(
-        Button::new("Activate")
-            .on_click(|_ctx, data: &mut State, _env| {
-                // TODO: store the autosplitter to be activated somewhere
-                let timer = data.timer.get_timer();
-                let game_name = timer.run().game_name();
-                if let Some(auto_splitter) = auto_splitters::get_list().get_for_game(game_name) {
-                    // TODO: allow an auto_splitter with AutoSplittingRuntime child support
-                    if !auto_splitter.is_using_auto_splitting_runtime() {
-                        show_error(anyhow::Error::msg(
-                            "This game's auto splitter is incompatible with LiveSplit One.",
-                        ));
-                    } else if let Some(auto_splitter_path) = auto_splitters::get_downloader()
-                        .download_for_game(
-                            auto_splitters::get_list(),
-                            game_name,
-                            auto_splitters::get_path(),
-                        )
-                    {
-                        let result = data.config.borrow_mut().open_auto_splitter(
-                            #[cfg(feature = "auto-splitting")]
-                            &data.timer,
-                            #[cfg(feature = "auto-splitting")]
-                            &data.runtime,
-                            &auto_splitter_path,
-                        );
-                        or_show_error(result);
+    Flex::row()
+        .with_flex_child(
+            Flex::column()
+                .with_child(
+                    Label::dynamic(|s: &State, _| s.game_name.to_string())
+                        .with_line_break_mode(LineBreaking::WordWrap)
+                        .with_text_alignment(TextAlignment::Center),
+                )
+                .with_child(
+                    Label::dynamic(|s: &State, _| {
+                        if let Some(auto_splitter) = &s.auto_splitter {
+                            // TODO: allow an auto_splitter with AutoSplittingRuntime child support
+                            if auto_splitter.is_using_auto_splitting_runtime() {
+                                auto_splitter.description.to_string()
+                            } else {
+                                "This game's auto splitter is incompatible with LiveSplit One."
+                                    .to_string()
+                            }
+                        } else {
+                            "No auto splitter available for this game.".to_string()
+                        }
+                    })
+                    .with_line_break_mode(LineBreaking::WordWrap)
+                    .with_text_alignment(TextAlignment::Center),
+                ),
+            1.0,
+        )
+        .with_spacer(BUTTON_SPACING)
+        .with_child(
+            Button::new("Activate")
+                .on_click(|_ctx, data: &mut State, _env| {
+                    let game_name = &data.game_name;
+                    if let Some(auto_splitter) = &data.auto_splitter {
+                        // TODO: allow an auto_splitter with AutoSplittingRuntime child support
+                        if !auto_splitter.is_using_auto_splitting_runtime() {
+                            show_error(anyhow::Error::msg(
+                                "This game's auto splitter is incompatible with LiveSplit One.",
+                            ));
+                        } else if let Some(auto_splitter_path) = auto_splitters::get_downloader()
+                            .download_for_game(
+                                auto_splitters::get_list(),
+                                game_name,
+                                auto_splitters::get_path(),
+                            )
+                        {
+                            let result = data.config.borrow_mut().open_auto_splitter(
+                                #[cfg(feature = "auto-splitting")]
+                                &data.timer,
+                                #[cfg(feature = "auto-splitting")]
+                                &data.runtime,
+                                &auto_splitter_path,
+                            );
+                            or_show_error(result);
+                        } else {
+                            show_error(anyhow::Error::msg(
+                                "Couldn't download the auto splitter files.",
+                            ));
+                        }
                     } else {
                         show_error(anyhow::Error::msg(
-                            "Couldn't download the auto splitter files.",
+                            "No auto splitter available for this game.",
                         ));
                     }
-                } else {
-                    show_error(anyhow::Error::msg(
-                        "No auto splitter available for this game.",
-                    ));
-                }
-            })
-            .disabled_if(|s: &State, _| s.use_local_auto_splitter),
-    )
+                })
+                .disabled_if(|s: &State, _| s.use_local_auto_splitter),
+        )
 }
 
 fn use_local_auto_splitter_widget() -> impl Widget<State> {
@@ -210,6 +245,9 @@ fn use_local_auto_splitter_widget() -> impl Widget<State> {
                     |s: &State| s.use_local_auto_splitter,
                     |s: &mut State, val: bool| {
                         s.use_local_auto_splitter = val;
+                        // TODO: if !val then load externally fixed
+                        // auto splitter if already activated?
+                        // and different from current loaded_path
                     },
                 ))
                 .center(),
@@ -218,15 +256,20 @@ fn use_local_auto_splitter_widget() -> impl Widget<State> {
 
 fn local_auto_splitter_path_widget() -> impl Widget<State> {
     Flex::row()
-        .with_child(Label::dynamic(|s: &State, _| {
-            s.runtime
-                .loaded_path()
-                .unwrap_or_default()
-                .file_name()
-                .unwrap_or_default()
-                .to_string_lossy()
-                .to_string()
-        }))
+        .with_flex_child(
+            Label::dynamic(|s: &State, _| {
+                s.runtime
+                    .loaded_path()
+                    .unwrap_or_default()
+                    .file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .to_string()
+            })
+            .with_line_break_mode(LineBreaking::WordWrap)
+            .with_text_alignment(TextAlignment::Center),
+            1.0,
+        )
         .with_spacer(BUTTON_SPACING)
         .with_child(
             Button::new("Open Auto-splitter")

--- a/src/autosplitter_choice_editor.rs
+++ b/src/autosplitter_choice_editor.rs
@@ -212,6 +212,7 @@ fn external_auto_splitter_widget() -> impl Widget<State> {
                                 auto_splitters::get_path(),
                             )
                         {
+                            // TODO: store auto_splitter_path as downloaded in config
                             let result = data.config.borrow_mut().open_auto_splitter(
                                 #[cfg(feature = "auto-splitting")]
                                 &data.timer,
@@ -231,7 +232,13 @@ fn external_auto_splitter_widget() -> impl Widget<State> {
                         ));
                     }
                 })
-                .disabled_if(|s: &State, _| s.use_local_auto_splitter),
+                .disabled_if(|s: &State, _| {
+                    // TODO: allow an auto_splitter with AutoSplittingRuntime child support
+                    s.use_local_auto_splitter
+                        || s.auto_splitter
+                            .as_ref()
+                            .is_none_or(|a| !a.is_using_auto_splitting_runtime())
+                }),
         )
 }
 

--- a/src/autosplitter_choice_editor.rs
+++ b/src/autosplitter_choice_editor.rs
@@ -1,0 +1,131 @@
+use std::{
+    path::{Path, PathBuf},
+    rc::Rc,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use druid::{
+    commands,
+    widget::{Button, Flex, ListIter, Scroll},
+    Data, Widget, WidgetExt,
+};
+
+use livesplit_core::{
+    auto_splitting::{
+        settings::{
+            FileFilter, Map as SettingsMap, Value as SettingValue, Widget as SettingsWidget,
+            WidgetKind,
+        },
+        wasi_path, Runtime,
+    },
+    event::CommandSink,
+    SharedTimer, StoredAutoSplitterSettings,
+};
+
+use crate::{
+    combo_box,
+    config::Config,
+    consts::{BUTTON_SPACING, DIALOG_BUTTON_HEIGHT, DIALOG_BUTTON_WIDTH, MARGIN},
+};
+
+#[derive(Clone, Data)]
+pub struct State {
+    use_local_auto_splitter: bool,
+    #[data(ignore)]
+    pub runtime: Rc<Runtime<SharedTimer>>,
+    #[data(ignore)]
+    pub closed_with_ok: bool,
+    /// Original use_local_auto_splitter value when the dialog was opened,
+    /// used to revert on cancel
+    #[data(ignore)]
+    original_use_local_auto_splitter: bool,
+    /// Original loaded_path when the dialog was opened, used to revert on cancel.
+    #[data(ignore)]
+    original_loaded_path: Option<PathBuf>,
+    /// Original settings map when the dialog was opened, used to revert on cancel.
+    #[data(ignore)]
+    original_settings: Option<SettingsMap>,
+}
+
+impl State {
+    pub(crate) fn new(runtime: Rc<Runtime<SharedTimer>>, use_local_auto_splitter: bool) -> Self {
+        let settings_map = runtime.settings_map();
+        Self {
+            use_local_auto_splitter,
+            original_use_local_auto_splitter: use_local_auto_splitter,
+            original_loaded_path: runtime.loaded_path(),
+            original_settings: settings_map,
+            runtime,
+            closed_with_ok: false,
+        }
+    }
+
+    /// Revert the runtime settings to the original state when the dialog was opened.
+    pub(crate) fn revert_settings(&self, config: &mut Config, timer: SharedTimer) {
+        config.set_use_local_auto_splitter(self.original_use_local_auto_splitter);
+        let settings = self.original_settings.clone().unwrap_or_default();
+        if &self.runtime.loaded_path() == &self.original_loaded_path {
+            self.runtime.set_settings_map(settings);
+        } else {
+            self.runtime.unload().ok();
+            let mut s = StoredAutoSplitterSettings::new();
+            if self.original_use_local_auto_splitter {
+                s.set_script_path(
+                    self.original_loaded_path
+                        .as_ref()
+                        .map(|p| p.to_string_lossy()),
+                );
+            }
+            s.set_settings_map(settings);
+            drop(timer.set_auto_splitter_settings(s));
+            if self.original_use_local_auto_splitter {
+                self.runtime.load(timer).ok();
+            } else if let Some(p) = &self.original_loaded_path {
+                self.runtime.load_from_path(timer, p.to_path_buf()).ok();
+            } else {
+                self.runtime.load(timer).ok();
+            }
+        }
+    }
+}
+
+pub fn root_widget() -> impl Widget<State> {
+    Flex::column()
+        .with_flex_child(settings_editor(), 1.0)
+        .with_child(dialog_buttons())
+}
+
+fn settings_editor() -> impl Widget<State> {
+    Scroll::new(settings_widget().padding(MARGIN))
+        .vertical()
+        .expand_height()
+}
+
+fn settings_widget() -> impl Widget<State> {
+    Flex::row()
+        .with_spacer(BUTTON_SPACING)
+}
+
+fn dialog_buttons() -> impl Widget<State> {
+    Flex::row()
+        .with_flex_spacer(1.0)
+        .with_child(
+            Button::new("OK")
+                .on_click(|ctx, state: &mut State, _| {
+                    // Changes are applied immediately in for_each_mut, so just close
+                    state.closed_with_ok = true;
+                    ctx.submit_command(commands::CLOSE_WINDOW);
+                })
+                .fix_size(DIALOG_BUTTON_WIDTH, DIALOG_BUTTON_HEIGHT),
+        )
+        .with_spacer(BUTTON_SPACING)
+        .with_child(
+            Button::new("Cancel")
+                .on_click(|ctx, _, _| {
+                    ctx.submit_command(commands::CLOSE_WINDOW);
+                })
+                .fix_size(DIALOG_BUTTON_WIDTH, DIALOG_BUTTON_HEIGHT),
+        )
+        .padding(MARGIN)
+}

--- a/src/autosplitter_choice_editor.rs
+++ b/src/autosplitter_choice_editor.rs
@@ -1,4 +1,5 @@
 use std::{
+    cell::RefCell,
     path::{Path, PathBuf},
     rc::Rc,
     sync::Arc,
@@ -7,8 +8,10 @@ use std::{
 
 use druid::{
     commands,
-    widget::{Button, Flex, ListIter, Scroll},
-    Data, Widget, WidgetExt,
+    lens::Identity,
+    widget::{Button, Controller, Flex, Label, ListIter, Scroll, Switch},
+    Data, Env, Event, EventCtx, FileDialogOptions, FileInfo, FileSpec, LensExt, LifeCycle,
+    LifeCycleCtx, Selector, Widget, WidgetExt,
 };
 
 use livesplit_core::{
@@ -29,11 +32,18 @@ use crate::{
     consts::{BUTTON_SPACING, DIALOG_BUTTON_HEIGHT, DIALOG_BUTTON_WIDTH, MARGIN},
 };
 
+const CHOICE_EDITOR_OPEN_AUTO_SPLITTER: Selector<FileInfo> =
+    Selector::new("autosplitter-choice-editor-open-auto-splitter");
+
 #[derive(Clone, Data)]
 pub struct State {
     use_local_auto_splitter: bool,
     #[data(ignore)]
+    pub timer: SharedTimer,
+    #[data(ignore)]
     pub runtime: Rc<Runtime<SharedTimer>>,
+    #[data(ignore)]
+    pub config: Rc<RefCell<Config>>,
     #[data(ignore)]
     pub closed_with_ok: bool,
     /// Original use_local_auto_splitter value when the dialog was opened,
@@ -49,21 +59,30 @@ pub struct State {
 }
 
 impl State {
-    pub(crate) fn new(runtime: Rc<Runtime<SharedTimer>>, use_local_auto_splitter: bool) -> Self {
+    pub(crate) fn new(
+        timer: SharedTimer,
+        runtime: Rc<Runtime<SharedTimer>>,
+        config: Rc<RefCell<Config>>,
+    ) -> Self {
         let settings_map = runtime.settings_map();
+        let use_local_auto_splitter = config.borrow().get_use_local_auto_splitter();
         Self {
             use_local_auto_splitter,
             original_use_local_auto_splitter: use_local_auto_splitter,
             original_loaded_path: runtime.loaded_path(),
             original_settings: settings_map,
+            timer,
             runtime,
+            config,
             closed_with_ok: false,
         }
     }
 
     /// Revert the runtime settings to the original state when the dialog was opened.
-    pub(crate) fn revert_settings(&self, config: &mut Config, timer: SharedTimer) {
-        config.set_use_local_auto_splitter(self.original_use_local_auto_splitter);
+    pub(crate) fn revert_settings(&self) {
+        self.config
+            .borrow_mut()
+            .set_use_local_auto_splitter(self.original_use_local_auto_splitter);
         let settings = self.original_settings.clone().unwrap_or_default();
         if &self.runtime.loaded_path() == &self.original_loaded_path {
             self.runtime.set_settings_map(settings);
@@ -78,13 +97,15 @@ impl State {
                 );
             }
             s.set_settings_map(settings);
-            drop(timer.set_auto_splitter_settings(s));
+            drop(self.timer.set_auto_splitter_settings(s));
             if self.original_use_local_auto_splitter {
-                self.runtime.load(timer).ok();
+                self.runtime.load(self.timer.clone()).ok();
             } else if let Some(p) = &self.original_loaded_path {
-                self.runtime.load_from_path(timer, p.to_path_buf()).ok();
+                self.runtime
+                    .load_from_path(self.timer.clone(), p.to_path_buf())
+                    .ok();
             } else {
-                self.runtime.load(timer).ok();
+                self.runtime.load(self.timer.clone()).ok();
             }
         }
     }
@@ -94,6 +115,48 @@ pub fn root_widget() -> impl Widget<State> {
     Flex::column()
         .with_flex_child(settings_editor(), 1.0)
         .with_child(dialog_buttons())
+        .controller(SyncController)
+}
+
+struct SyncController;
+
+impl<W: Widget<State>> Controller<State, W> for SyncController {
+    fn event(
+        &mut self,
+        child: &mut W,
+        ctx: &mut EventCtx,
+        event: &Event,
+        data: &mut State,
+        env: &Env,
+    ) {
+        // Handle file dialog request command
+        if let Event::Command(cmd) = event {
+            if let Some(file_info) = cmd.get(CHOICE_EDITOR_OPEN_AUTO_SPLITTER) {
+                data.runtime
+                    .load_from_path(data.timer.clone(), file_info.path().to_path_buf());
+
+                ctx.set_handled();
+                return;
+            }
+        }
+
+        child.event(ctx, event, data, env);
+    }
+
+    fn lifecycle(
+        &mut self,
+        child: &mut W,
+        ctx: &mut LifeCycleCtx,
+        event: &LifeCycle,
+        data: &State,
+        env: &Env,
+    ) {
+        if let LifeCycle::WidgetAdded = event {
+            // Start the animation frame loop
+            ctx.request_anim_frame();
+        }
+        child.lifecycle(ctx, event, data, env);
+    }
 }
 
 fn settings_editor() -> impl Widget<State> {
@@ -103,7 +166,63 @@ fn settings_editor() -> impl Widget<State> {
 }
 
 fn settings_widget() -> impl Widget<State> {
-    Flex::row().with_spacer(BUTTON_SPACING)
+    Flex::column()
+        .with_child(external_auto_splitter_widget())
+        .with_child(use_local_auto_splitter_widget())
+        .with_child(local_auto_splitter_path_widget())
+}
+
+fn external_auto_splitter_widget() -> impl Widget<State> {
+    Flex::row().with_spacer(BUTTON_SPACING).with_child(
+        Button::new("Activate")
+            .on_click(|_ctx, s: &mut State, _env| {
+                // TODO: store the autosplitter to be activated somewhere
+                todo!("Activate")
+            })
+            .disabled_if(|s: &State, _| s.use_local_auto_splitter),
+    )
+}
+
+fn use_local_auto_splitter_widget() -> impl Widget<State> {
+    Flex::row()
+        .with_child(Label::new("Use local auto splitter"))
+        .with_spacer(BUTTON_SPACING)
+        .with_child(
+            Switch::new()
+                .lens(Identity.map(
+                    |s: &State| s.use_local_auto_splitter,
+                    |s: &mut State, val: bool| {
+                        s.use_local_auto_splitter = val;
+                    },
+                ))
+                .center(),
+        )
+}
+
+fn local_auto_splitter_path_widget() -> impl Widget<State> {
+    Flex::row()
+        .with_spacer(BUTTON_SPACING)
+        .with_child(
+            Button::new("Open Auto-splitter").on_click(|ctx, _s: &mut State, _env| {
+                let open_dialog = commands::SHOW_OPEN_PANEL.with(
+                    FileDialogOptions::new()
+                        .title("Open Auto-splitter")
+                        .allowed_types(vec![
+                            FileSpec {
+                                name: "WASM Auto-splitters",
+                                extensions: &["wasm"],
+                            },
+                            FileSpec {
+                                name: "All Files",
+                                extensions: &["*.*"],
+                            },
+                        ])
+                        .accept_command(CHOICE_EDITOR_OPEN_AUTO_SPLITTER),
+                );
+                ctx.submit_command(open_dialog);
+            }),
+        )
+        .disabled_if(|s: &State, _| !s.use_local_auto_splitter)
 }
 
 fn dialog_buttons() -> impl Widget<State> {

--- a/src/autosplitter_choice_editor.rs
+++ b/src/autosplitter_choice_editor.rs
@@ -212,8 +212,9 @@ fn external_auto_splitter_widget() -> impl Widget<State> {
                                 auto_splitters::get_path(),
                             )
                         {
-                            // TODO: store auto_splitter_path as downloaded in config
-                            let result = data.config.borrow_mut().open_auto_splitter(
+                            let mut config = data.config.borrow_mut();
+                            config.add_to_auto_splitters(game_name, &auto_splitter_path);
+                            let result = config.open_auto_splitter(
                                 #[cfg(feature = "auto-splitting")]
                                 &data.timer,
                                 #[cfg(feature = "auto-splitting")]

--- a/src/autosplitter_editor.rs
+++ b/src/autosplitter_editor.rs
@@ -1,5 +1,5 @@
 use std::{
-    path::Path,
+    path::{Path, PathBuf},
     rc::Rc,
     sync::Arc,
     time::{Duration, Instant},
@@ -21,11 +21,13 @@ use livesplit_core::{
         },
         wasi_path, Runtime,
     },
-    SharedTimer,
+    event::CommandSink,
+    SharedTimer, StoredAutoSplitterSettings,
 };
 
 use crate::{
     combo_box,
+    config::Config,
     consts::{BUTTON_SPACING, DIALOG_BUTTON_HEIGHT, DIALOG_BUTTON_WIDTH, MARGIN},
 };
 
@@ -41,11 +43,19 @@ const FILE_DIALOG_RESULT: Selector<(Arc<str>, std::path::PathBuf)> =
 
 #[derive(Clone, Data)]
 pub struct State {
+    use_local_auto_splitter: bool,
     rows: Arc<Vec<SettingRow>>,
     #[data(ignore)]
     pub runtime: Rc<Runtime<SharedTimer>>,
     #[data(ignore)]
     pub closed_with_ok: bool,
+    /// Original use_local_auto_splitter value when the dialog was opened,
+    /// used to revert on cancel
+    #[data(ignore)]
+    original_use_local_auto_splitter: bool,
+    /// Original loaded_path when the dialog was opened, used to revert on cancel.
+    #[data(ignore)]
+    original_loaded_path: Option<PathBuf>,
     /// Original settings map when the dialog was opened, used to revert on cancel.
     #[data(ignore)]
     original_settings: Option<SettingsMap>,
@@ -93,12 +103,15 @@ impl Data for ChoiceOption {
 }
 
 impl State {
-    pub(crate) fn new(runtime: Rc<Runtime<SharedTimer>>) -> Self {
+    pub(crate) fn new(runtime: Rc<Runtime<SharedTimer>>, use_local_auto_splitter: bool) -> Self {
         let widgets = runtime.settings_widgets().unwrap_or_default();
         let settings_map = runtime.settings_map();
         let rows = build_rows(&widgets, settings_map.as_ref());
         Self {
+            use_local_auto_splitter,
             rows: Arc::new(rows),
+            original_use_local_auto_splitter: use_local_auto_splitter,
+            original_loaded_path: runtime.loaded_path(),
             original_settings: settings_map,
             runtime,
             closed_with_ok: false,
@@ -106,9 +119,31 @@ impl State {
     }
 
     /// Revert the runtime settings to the original state when the dialog was opened.
-    pub(crate) fn revert_settings(&self) {
+    pub(crate) fn revert_settings(&self, config: &mut Config, timer: SharedTimer) {
+        config.set_use_local_auto_splitter(self.original_use_local_auto_splitter);
         let settings = self.original_settings.clone().unwrap_or_default();
-        self.runtime.set_settings_map(settings);
+        if &self.runtime.loaded_path() == &self.original_loaded_path {
+            self.runtime.set_settings_map(settings);
+        } else {
+            self.runtime.unload().ok();
+            let mut s = StoredAutoSplitterSettings::new();
+            if self.original_use_local_auto_splitter {
+                s.set_script_path(
+                    self.original_loaded_path
+                        .as_ref()
+                        .map(|p| p.to_string_lossy()),
+                );
+            }
+            s.set_settings_map(settings);
+            drop(timer.set_auto_splitter_settings(s));
+            if self.original_use_local_auto_splitter {
+                self.runtime.load(timer).ok();
+            } else if let Some(p) = &self.original_loaded_path {
+                self.runtime.load_from_path(timer, p.to_path_buf()).ok();
+            } else {
+                self.runtime.load(timer).ok();
+            }
+        }
     }
 
     /// Sync UI state with the runtime's current settings.

--- a/src/autosplitter_editor.rs
+++ b/src/autosplitter_editor.rs
@@ -1,5 +1,5 @@
 use std::{
-    path::{Path, PathBuf},
+    path::Path,
     rc::Rc,
     sync::Arc,
     time::{Duration, Instant},
@@ -21,13 +21,11 @@ use livesplit_core::{
         },
         wasi_path, Runtime,
     },
-    event::CommandSink,
-    SharedTimer, StoredAutoSplitterSettings,
+    SharedTimer,
 };
 
 use crate::{
     combo_box,
-    config::Config,
     consts::{BUTTON_SPACING, DIALOG_BUTTON_HEIGHT, DIALOG_BUTTON_WIDTH, MARGIN},
 };
 
@@ -43,19 +41,11 @@ const FILE_DIALOG_RESULT: Selector<(Arc<str>, std::path::PathBuf)> =
 
 #[derive(Clone, Data)]
 pub struct State {
-    use_local_auto_splitter: bool,
     rows: Arc<Vec<SettingRow>>,
     #[data(ignore)]
     pub runtime: Rc<Runtime<SharedTimer>>,
     #[data(ignore)]
     pub closed_with_ok: bool,
-    /// Original use_local_auto_splitter value when the dialog was opened,
-    /// used to revert on cancel
-    #[data(ignore)]
-    original_use_local_auto_splitter: bool,
-    /// Original loaded_path when the dialog was opened, used to revert on cancel.
-    #[data(ignore)]
-    original_loaded_path: Option<PathBuf>,
     /// Original settings map when the dialog was opened, used to revert on cancel.
     #[data(ignore)]
     original_settings: Option<SettingsMap>,
@@ -103,15 +93,12 @@ impl Data for ChoiceOption {
 }
 
 impl State {
-    pub(crate) fn new(runtime: Rc<Runtime<SharedTimer>>, use_local_auto_splitter: bool) -> Self {
+    pub(crate) fn new(runtime: Rc<Runtime<SharedTimer>>) -> Self {
         let widgets = runtime.settings_widgets().unwrap_or_default();
         let settings_map = runtime.settings_map();
         let rows = build_rows(&widgets, settings_map.as_ref());
         Self {
-            use_local_auto_splitter,
             rows: Arc::new(rows),
-            original_use_local_auto_splitter: use_local_auto_splitter,
-            original_loaded_path: runtime.loaded_path(),
             original_settings: settings_map,
             runtime,
             closed_with_ok: false,
@@ -119,31 +106,9 @@ impl State {
     }
 
     /// Revert the runtime settings to the original state when the dialog was opened.
-    pub(crate) fn revert_settings(&self, config: &mut Config, timer: SharedTimer) {
-        config.set_use_local_auto_splitter(self.original_use_local_auto_splitter);
+    pub(crate) fn revert_settings(&self) {
         let settings = self.original_settings.clone().unwrap_or_default();
-        if &self.runtime.loaded_path() == &self.original_loaded_path {
-            self.runtime.set_settings_map(settings);
-        } else {
-            self.runtime.unload().ok();
-            let mut s = StoredAutoSplitterSettings::new();
-            if self.original_use_local_auto_splitter {
-                s.set_script_path(
-                    self.original_loaded_path
-                        .as_ref()
-                        .map(|p| p.to_string_lossy()),
-                );
-            }
-            s.set_settings_map(settings);
-            drop(timer.set_auto_splitter_settings(s));
-            if self.original_use_local_auto_splitter {
-                self.runtime.load(timer).ok();
-            } else if let Some(p) = &self.original_loaded_path {
-                self.runtime.load_from_path(timer, p.to_path_buf()).ok();
-            } else {
-                self.runtime.load(timer).ok();
-            }
-        }
+        self.runtime.set_settings_map(settings);
     }
 
     /// Sync UI state with the runtime's current settings.

--- a/src/config.rs
+++ b/src/config.rs
@@ -410,7 +410,7 @@ impl Config {
         }
 
         #[cfg(feature = "auto-splitting")]
-        auto_splitter.reload(shared_timer.clone())?;
+        reload(auto_splitter, shared_timer);
 
         Ok(())
     }
@@ -428,7 +428,7 @@ impl Config {
     ) -> Result<()> {
         if let Some(path) = &self.splits.current {
             #[cfg(feature = "auto-splitting")]
-            timer.run_auto_splitter_settings_map_store(runtime.settings_map().unwrap_or_default());
+            runtime.store_settings();
             let mut buf = String::new();
             save_timer(timer, &mut buf).context("Failed saving the splits.")?;
             fs::write(path, &buf)
@@ -452,7 +452,7 @@ impl Config {
         path: PathBuf,
     ) -> Result<()> {
         #[cfg(feature = "auto-splitting")]
-        timer.run_auto_splitter_settings_map_store(runtime.settings_map().unwrap_or_default());
+        runtime.store_settings();
         let mut buf = String::new();
         save_timer(timer, &mut buf).context("Failed saving the splits.")?;
         fs::write(&path, &buf).context(format!("Failed writing the splits file to {:?}.", path))?;
@@ -561,7 +561,7 @@ impl Config {
         #[cfg(feature = "auto-splitting")]
         runtime.unload()?;
         #[cfg(feature = "auto-splitting")]
-        runtime.load(path.into(), shared_timer.clone())?;
+        runtime.load_from_path(shared_timer.clone(), path.into())?;
         Ok(())
     }
 
@@ -637,7 +637,7 @@ impl Config {
         timer: SharedTimer,
     ) {
         if let Some(auto_splitter) = &self.general.auto_splitter {
-            if let Err(e) = runtime.load(auto_splitter.clone(), timer) {
+            if let Err(e) = runtime.load_from_path(timer, auto_splitter.clone()) {
                 // TODO: Error chain
                 log::error!("Auto Splitter failed to load: {}", e);
             }
@@ -693,4 +693,18 @@ fn validate_position(position: impl Into<druid::Point>) -> Option<druid::Point> 
         }
     }
     None
+}
+
+#[cfg(feature = "auto-splitting")]
+fn reload(
+    auto_splitter: &livesplit_core::auto_splitting::Runtime<SharedTimer>,
+    shared_timer: &SharedTimer,
+) {
+    let mp = auto_splitter.loaded_path();
+    auto_splitter.unload().ok();
+    if let Some(p) = mp {
+        auto_splitter.load_from_path(shared_timer.clone(), p).ok();
+    } else {
+        auto_splitter.load(shared_timer.clone()).ok();
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -102,6 +102,17 @@ struct General {
     comparison: Option<String>,
     use_local_auto_splitter: bool,
     auto_splitter: Option<PathBuf>,
+    #[serde(default)]
+    auto_splitters: BTreeMap<Arc<str>, BTreeSet<Arc<Path>>>,
+}
+
+impl General {
+    fn add_to_auto_splitters(&mut self, game_name: &str, auto_splitter_path: &Path) {
+        self.auto_splitters
+            .entry(game_name.into())
+            .or_default()
+            .insert(auto_splitter_path.into());
+    }
 }
 
 #[derive(Default, Deserialize, Serialize)]
@@ -569,6 +580,11 @@ impl Config {
         self.general.use_local_auto_splitter = use_local_auto_splitter;
         self.general.auto_splitter = path.map(|p| p.to_path_buf());
         self.save_config();
+    }
+
+    pub fn add_to_auto_splitters(&mut self, game_name: &str, auto_splitter_path: &Path) {
+        self.general
+            .add_to_auto_splitters(game_name, auto_splitter_path);
     }
 
     // TODO: pass use_local_auto_splitter

--- a/src/config.rs
+++ b/src/config.rs
@@ -103,15 +103,17 @@ struct General {
     use_local_auto_splitter: bool,
     auto_splitter: Option<PathBuf>,
     #[serde(default)]
-    auto_splitters: BTreeMap<Arc<str>, BTreeSet<Arc<Path>>>,
+    auto_splitters: BTreeMap<Arc<str>, Arc<Path>>,
 }
 
 impl General {
+    fn get_game_auto_splitter(&self, game_name: &str) -> Option<&Path> {
+        self.auto_splitters.get(game_name).map(|p| p.as_ref())
+    }
+
     fn add_to_auto_splitters(&mut self, game_name: &str, auto_splitter_path: &Path) {
         self.auto_splitters
-            .entry(game_name.into())
-            .or_default()
-            .insert(auto_splitter_path.into());
+            .insert(game_name.into(), auto_splitter_path.into());
     }
 }
 
@@ -580,6 +582,10 @@ impl Config {
         self.general.use_local_auto_splitter = use_local_auto_splitter;
         self.general.auto_splitter = path.map(|p| p.to_path_buf());
         self.save_config();
+    }
+
+    pub fn get_game_auto_splitter(&self, game_name: &str) -> Option<&Path> {
+        self.general.get_game_auto_splitter(game_name)
     }
 
     pub fn add_to_auto_splitters(&mut self, game_name: &str, auto_splitter_path: &Path) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -97,6 +97,7 @@ struct General {
     can_save_layout: bool,
     timing_method: Option<TimingMethod>,
     comparison: Option<String>,
+    use_local_auto_splitter: bool,
     auto_splitter: Option<PathBuf>,
 }
 
@@ -553,6 +554,14 @@ impl Config {
 
     pub fn can_directly_save_layout(&self) -> bool {
         self.general.layout.is_some() && self.general.can_save_layout
+    }
+
+    pub fn get_use_local_auto_splitter(&self) -> bool {
+        self.general.use_local_auto_splitter
+    }
+
+    pub fn set_use_local_auto_splitter(&mut self, use_local_auto_splitter: bool) {
+        self.general.use_local_auto_splitter = use_local_auto_splitter
     }
 
     pub fn open_auto_splitter(

--- a/src/config.rs
+++ b/src/config.rs
@@ -185,6 +185,13 @@ static CONFIG_PATH: Lazy<PathBuf> = Lazy::new(|| {
         .unwrap_or_default()
 });
 
+#[cfg(feature = "auto-splitting")]
+pub fn get_config_folder() -> Option<&'static std::path::Path> {
+    let config_folder = CONFIG_PATH.parent()?;
+    create_dir_all(config_folder).ok()?;
+    Some(config_folder)
+}
+
 impl Config {
     pub fn load(cli: cli::Cli) -> Self {
         let mut cfg = Self::parse().unwrap_or_default();

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,6 +25,9 @@ use std::{
 
 use crate::{cli, consts::TIMER_MIN_SIZE, server, timer_form, LayoutData, MainState};
 
+#[cfg(feature = "auto-splitting")]
+use livesplit_core::{event::CommandSink, StoredAutoSplitterSettings};
+
 #[derive(Default, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
@@ -560,10 +563,15 @@ impl Config {
         self.general.use_local_auto_splitter
     }
 
-    pub fn set_use_local_auto_splitter(&mut self, use_local_auto_splitter: bool) {
-        self.general.use_local_auto_splitter = use_local_auto_splitter
+    /// Should only be used in combination with one of the runtime load methods:
+    /// `load` or `load_from_path`.
+    fn set_auto_splitter(&mut self, use_local_auto_splitter: bool, path: Option<&Path>) {
+        self.general.use_local_auto_splitter = use_local_auto_splitter;
+        self.general.auto_splitter = path.map(|p| p.to_path_buf());
+        self.save_config();
     }
 
+    // TODO: pass use_local_auto_splitter
     pub fn open_auto_splitter(
         &mut self,
         #[cfg(feature = "auto-splitting")] shared_timer: &SharedTimer,
@@ -572,12 +580,45 @@ impl Config {
         >,
         path: &Path,
     ) -> Result<()> {
+        // TODO: save use_local_auto_splitter
         self.general.auto_splitter = Some(path.into());
         self.save_config();
         #[cfg(feature = "auto-splitting")]
         runtime.unload()?;
         #[cfg(feature = "auto-splitting")]
         runtime.load_from_path(shared_timer.clone(), path.into())?;
+        Ok(())
+    }
+
+    #[cfg(feature = "auto-splitting")]
+    pub fn revert_auto_splitter(
+        &mut self,
+        shared_timer: &SharedTimer,
+        runtime: &livesplit_core::auto_splitting::Runtime<SharedTimer>,
+        use_local_auto_splitter: bool,
+        path: Option<&Path>,
+        settings_map: Option<livesplit_core::auto_splitting::settings::Map>,
+    ) -> Result<()> {
+        self.set_auto_splitter(use_local_auto_splitter, path);
+        let settings = settings_map.unwrap_or_default();
+        if runtime.loaded_path().as_deref() == path {
+            runtime.set_settings_map(settings);
+        } else {
+            runtime.unload()?;
+            let mut s = StoredAutoSplitterSettings::new();
+            if use_local_auto_splitter {
+                s.set_script_path(path.map(|p| p.to_string_lossy()));
+            }
+            s.set_settings_map(settings);
+            drop(shared_timer.set_auto_splitter_settings(s));
+            if use_local_auto_splitter {
+                runtime.load(shared_timer.clone())?;
+            } else if let Some(p) = path {
+                runtime.load_from_path(shared_timer.clone(), p.to_path_buf())?;
+            } else {
+                runtime.load(shared_timer.clone())?;
+            }
+        }
         Ok(())
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -227,7 +227,11 @@ struct AutoSplitterChoiceEditorLens;
 
 #[cfg(feature = "auto-splitting")]
 impl Lens<MainState, autosplitter_choice_editor::State> for AutoSplitterChoiceEditorLens {
-    fn with<V, F: FnOnce(&autosplitter_choice_editor::State) -> V>(&self, data: &MainState, f: F) -> V {
+    fn with<V, F: FnOnce(&autosplitter_choice_editor::State) -> V>(
+        &self,
+        data: &MainState,
+        f: F,
+    ) -> V {
         f(&data.autosplitter_choice_editor.as_ref().unwrap().state)
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,8 @@ mod window_settings_editor;
 #[cfg(feature = "auto-splitting")]
 mod auto_splitters;
 #[cfg(feature = "auto-splitting")]
+mod autosplitter_choice_editor;
+#[cfg(feature = "auto-splitting")]
 mod autosplitter_editor;
 
 mod software_renderer;
@@ -75,6 +77,8 @@ pub struct MainState {
     layout_editor: Option<OpenWindow<layout_editor::State>>,
     window_settings_editor: Option<OpenWindow<window_settings_editor::State>>,
     hotkeys_editor: Option<OpenWindow<hotkeys_editor::State>>,
+    #[cfg(feature = "auto-splitting")]
+    autosplitter_choice_editor: Option<OpenWindow<autosplitter_choice_editor::State>>,
     #[cfg(feature = "auto-splitting")]
     autosplitter_editor: Option<OpenWindow<autosplitter_editor::State>>,
     server_editor: Option<OpenWindow<server_editor::State>>,
@@ -143,6 +147,8 @@ impl MainState {
             layout_editor: None,
             window_settings_editor: None,
             hotkeys_editor: None,
+            #[cfg(feature = "auto-splitting")]
+            autosplitter_choice_editor: None,
             #[cfg(feature = "auto-splitting")]
             autosplitter_editor: None,
             server_editor: None,
@@ -213,6 +219,24 @@ impl Lens<MainState, hotkeys_editor::State> for HotkeysEditorLens {
         f: F,
     ) -> V {
         f(&mut data.hotkeys_editor.as_mut().unwrap().state)
+    }
+}
+
+#[cfg(feature = "auto-splitting")]
+struct AutoSplitterChoiceEditorLens;
+
+#[cfg(feature = "auto-splitting")]
+impl Lens<MainState, autosplitter_choice_editor::State> for AutoSplitterChoiceEditorLens {
+    fn with<V, F: FnOnce(&autosplitter_choice_editor::State) -> V>(&self, data: &MainState, f: F) -> V {
+        f(&data.autosplitter_choice_editor.as_ref().unwrap().state)
+    }
+
+    fn with_mut<V, F: FnOnce(&mut autosplitter_choice_editor::State) -> V>(
+        &self,
+        data: &mut MainState,
+        f: F,
+    ) -> V {
+        f(&mut data.autosplitter_choice_editor.as_mut().unwrap().state)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,8 @@ mod timer_form;
 mod window_settings_editor;
 
 #[cfg(feature = "auto-splitting")]
+mod auto_splitters;
+#[cfg(feature = "auto-splitting")]
 mod autosplitter_editor;
 
 mod software_renderer;
@@ -116,6 +118,8 @@ impl MainState {
         let hotkey_system = config.configure_hotkeys(timer.clone());
         *HOTKEY_SYSTEM.write().unwrap() = Some(hotkey_system);
 
+        #[cfg(feature = "auto-splitting")]
+        auto_splitters::set_up();
         #[cfg(feature = "auto-splitting")]
         let auto_splitter = livesplit_core::auto_splitting::Runtime::new();
         #[cfg(feature = "auto-splitting")]

--- a/src/timer_form.rs
+++ b/src/timer_form.rs
@@ -17,9 +17,7 @@ use livesplit_core::{LayoutEditor, RunEditor, TimerPhase, TimingMethod};
 #[cfg(target_os = "linux")]
 use crate::consts::TIMER_MIN_SIZE;
 #[cfg(feature = "auto-splitting")]
-use crate::{config::show_error, auto_splitters, autosplitter_editor, AutoSplitterEditorLens};
-#[cfg(feature = "auto-splitting")]
-use livesplit_core::event::TimerQuery;
+use crate::{auto_splitters, autosplitter_editor, config::show_error, AutoSplitterEditorLens};
 use crate::{
     config::or_show_error,
     consts::{
@@ -31,6 +29,8 @@ use crate::{
     HotkeysEditorLens, LayoutEditorLens, MainState, OpenWindow, RunEditorLens, ServerEditorLens,
     WindowSettingsEditorLens, HOTKEY_SYSTEM,
 };
+#[cfg(feature = "auto-splitting")]
+use livesplit_core::event::TimerQuery;
 
 struct WithMenu<T> {
     // device: Device,
@@ -334,15 +334,12 @@ impl<T: Widget<MainState>> Widget<MainState> for WithMenu<T> {
                                         MenuItem::new("Activate Game Auto-splitter")
                                             .command(CONTEXT_MENU_ACTIVATE_AUTO_SPLITTER),
                                     )
-                                    .entry(
-                                        MenuItem::new("Open Local Auto-splitter...").command(
-                                            CONTEXT_MENU_SET_INTENT.with(Intent::OPEN_AUTO_SPLITTER),
-                                        ),
-                                    )
+                                    .entry(MenuItem::new("Open Local Auto-splitter...").command(
+                                        CONTEXT_MENU_SET_INTENT.with(Intent::OPEN_AUTO_SPLITTER),
+                                    ))
                                     .entry(
                                         MenuItem::new("Edit Auto-splitter Settings...")
                                             .command(CONTEXT_MENU_EDIT_AUTOSPLITTER_SETTINGS),
-                                        
                                     ),
                                 #[cfg(not(feature = "auto-splitting"))]
                                 MenuItem::new("Auto-splitting unavailable").enabled(false),
@@ -559,14 +556,19 @@ impl<T: Widget<MainState>> Widget<MainState> for WithMenu<T> {
                     // TODO
                     let timer = data.timer.get_timer();
                     let game_name = timer.run().game_name();
-                    if let Some(auto_splitter) = auto_splitters::get_list().get_for_game(game_name) {
+                    if let Some(auto_splitter) = auto_splitters::get_list().get_for_game(game_name)
+                    {
                         if !auto_splitter.is_using_auto_splitting_runtime() {
-                            show_error(anyhow::Error::msg("This game's auto splitter is incompatible with LiveSplit One."));
-                        } else if let Some(auto_splitter_path) = auto_splitters::get_downloader().download_for_game(
-                            auto_splitters::get_list(),
-                            game_name,
-                            auto_splitters::get_path(),
-                        ) {
+                            show_error(anyhow::Error::msg(
+                                "This game's auto splitter is incompatible with LiveSplit One.",
+                            ));
+                        } else if let Some(auto_splitter_path) = auto_splitters::get_downloader()
+                            .download_for_game(
+                                auto_splitters::get_list(),
+                                game_name,
+                                auto_splitters::get_path(),
+                            )
+                        {
                             let result = data.config.borrow_mut().open_auto_splitter(
                                 #[cfg(feature = "auto-splitting")]
                                 &data.timer,
@@ -576,10 +578,14 @@ impl<T: Widget<MainState>> Widget<MainState> for WithMenu<T> {
                             );
                             or_show_error(result);
                         } else {
-                            show_error(anyhow::Error::msg("Couldn't download the auto splitter files."));
+                            show_error(anyhow::Error::msg(
+                                "Couldn't download the auto splitter files.",
+                            ));
                         }
                     } else {
-                        show_error(anyhow::Error::msg("No auto splitter available for this game."));
+                        show_error(anyhow::Error::msg(
+                            "No auto splitter available for this game.",
+                        ));
                     }
                 }
                 #[cfg(feature = "auto-splitting")]

--- a/src/timer_form.rs
+++ b/src/timer_form.rs
@@ -557,21 +557,29 @@ impl<T: Widget<MainState>> Widget<MainState> for WithMenu<T> {
                 #[cfg(feature = "auto-splitting")]
                 if command.is(CONTEXT_MENU_ACTIVATE_AUTO_SPLITTER) {
                     // TODO
-                    if let Some(auto_splitter_path) = auto_splitters::get_downloader().download_for_game(
-                        auto_splitters::get_list(),
-                        data.timer.get_timer().run().game_name(),
-                        auto_splitters::get_path(),
-                    ) {
-                        let result = data.config.borrow_mut().open_auto_splitter(
-                            #[cfg(feature = "auto-splitting")]
-                            &data.timer,
-                            #[cfg(feature = "auto-splitting")]
-                            &data.auto_splitter,
-                            &auto_splitter_path,
-                        );
-                        or_show_error(result);
+                    let timer = data.timer.get_timer();
+                    let game_name = timer.run().game_name();
+                    if let Some(auto_splitter) = auto_splitters::get_list().get_for_game(game_name) {
+                        if !auto_splitter.is_using_auto_splitting_runtime() {
+                            show_error(anyhow::Error::msg("This game's auto splitter is incompatible with LiveSplit One."));
+                        } else if let Some(auto_splitter_path) = auto_splitters::get_downloader().download_for_game(
+                            auto_splitters::get_list(),
+                            game_name,
+                            auto_splitters::get_path(),
+                        ) {
+                            let result = data.config.borrow_mut().open_auto_splitter(
+                                #[cfg(feature = "auto-splitting")]
+                                &data.timer,
+                                #[cfg(feature = "auto-splitting")]
+                                &data.auto_splitter,
+                                &auto_splitter_path,
+                            );
+                            or_show_error(result);
+                        } else {
+                            show_error(anyhow::Error::msg("Couldn't download the auto splitter files."));
+                        }
                     } else {
-                        show_error(anyhow::Error::msg("Couldn't download the auto splitter files."));
+                        show_error(anyhow::Error::msg("No auto splitter available for this game."));
                     }
                 }
                 #[cfg(feature = "auto-splitting")]

--- a/src/timer_form.rs
+++ b/src/timer_form.rs
@@ -600,9 +600,14 @@ impl<T: Widget<MainState>> Widget<MainState> for WithMenu<T> {
                     .set_always_on_top(true);
                     let window_id = window.id;
                     ctx.new_window(window);
+                    let use_local_auto_splitter =
+                        data.config.borrow().get_use_local_auto_splitter();
                     data.autosplitter_editor = Some(OpenWindow {
                         id: window_id,
-                        state: autosplitter_editor::State::new(data.auto_splitter.clone()),
+                        state: autosplitter_editor::State::new(
+                            data.auto_splitter.clone(),
+                            use_local_auto_splitter,
+                        ),
                     });
                 }
                 if let Some(intent) = command.get(CONTEXT_MENU_SET_INTENT) {
@@ -1339,7 +1344,9 @@ impl AppDelegate<MainState> for WindowManagement {
         if let Some(window) = &data.autosplitter_editor {
             if id == window.id {
                 if !window.state.closed_with_ok {
-                    window.state.revert_settings();
+                    window
+                        .state
+                        .revert_settings(&mut data.config.borrow_mut(), data.timer.clone());
                 }
                 data.autosplitter_editor = None;
                 return;

--- a/src/timer_form.rs
+++ b/src/timer_form.rs
@@ -17,7 +17,7 @@ use livesplit_core::{LayoutEditor, RunEditor, TimerPhase, TimingMethod};
 #[cfg(target_os = "linux")]
 use crate::consts::TIMER_MIN_SIZE;
 #[cfg(feature = "auto-splitting")]
-use crate::{auto_splitters, autosplitter_editor, config::show_error, AutoSplitterEditorLens};
+use crate::{auto_splitters, autosplitter_choice_editor, autosplitter_editor, config::show_error, AutoSplitterChoiceEditorLens, AutoSplitterEditorLens};
 use crate::{
     config::or_show_error,
     consts::{
@@ -146,7 +146,11 @@ impl<T: Widget<MainState>> Widget<MainState> for WithMenu<T> {
             }
             Event::MouseUp(event) => {
                 #[cfg(feature = "auto-splitting")]
+                let autosplitter_choice_editor_is_none = data.autosplitter_choice_editor.is_none();
+                #[cfg(feature = "auto-splitting")]
                 let autosplitter_editor_is_none = data.autosplitter_editor.is_none();
+                #[cfg(not(feature = "auto-splitting"))]
+                let autosplitter_choice_editor_is_none = true;
                 #[cfg(not(feature = "auto-splitting"))]
                 let autosplitter_editor_is_none = true;
 
@@ -155,6 +159,7 @@ impl<T: Widget<MainState>> Widget<MainState> for WithMenu<T> {
                     && data.layout_editor.is_none()
                     && data.window_settings_editor.is_none()
                     && data.hotkeys_editor.is_none()
+                    && autosplitter_choice_editor_is_none
                     && autosplitter_editor_is_none
                     && data.server_editor.is_none()
                 {
@@ -587,6 +592,28 @@ impl<T: Widget<MainState>> Widget<MainState> for WithMenu<T> {
                             "No auto splitter available for this game.",
                         ));
                     }
+                }
+                #[cfg(feature = "auto-splitting")]
+                if command.is(CONTEXT_MENU_OPEN_AUTO_SPLITTER) {
+                    let window = WindowDesc::new(
+                        autosplitter_choice_editor::root_widget().lens(AutoSplitterChoiceEditorLens),
+                    )
+                    .title("Open Auto-splitter")
+                    .with_min_size((550.0, 400.0))
+                    .window_size((550.0, 450.0))
+                    .set_level(WindowLevel::AppWindow)
+                    .set_always_on_top(true);
+                    let window_id = window.id;
+                    ctx.new_window(window);
+                    let use_local_auto_splitter =
+                        data.config.borrow().get_use_local_auto_splitter();
+                    data.autosplitter_choice_editor = Some(OpenWindow {
+                        id: window_id,
+                        state: autosplitter_choice_editor::State::new(
+                            data.auto_splitter.clone(),
+                            use_local_auto_splitter,
+                        ),
+                    });
                 }
                 #[cfg(feature = "auto-splitting")]
                 if command.is(CONTEXT_MENU_EDIT_AUTOSPLITTER_SETTINGS) {
@@ -1336,6 +1363,19 @@ impl AppDelegate<MainState> for WindowManagement {
                         .set_mouse_pass_through_while_running(mouse_pass_through_while_running);
                 }
                 data.window_settings_editor = None;
+                return;
+            }
+        }
+
+        #[cfg(feature = "auto-splitting")]
+        if let Some(window) = &data.autosplitter_choice_editor {
+            if id == window.id {
+                if !window.state.closed_with_ok {
+                    window
+                        .state
+                        .revert_settings(&mut data.config.borrow_mut(), data.timer.clone());
+                }
+                data.autosplitter_choice_editor = None;
                 return;
             }
         }

--- a/src/timer_form.rs
+++ b/src/timer_form.rs
@@ -609,13 +609,12 @@ impl<T: Widget<MainState>> Widget<MainState> for WithMenu<T> {
                     .set_always_on_top(true);
                     let window_id = window.id;
                     ctx.new_window(window);
-                    let use_local_auto_splitter =
-                        data.config.borrow().get_use_local_auto_splitter();
                     data.autosplitter_choice_editor = Some(OpenWindow {
                         id: window_id,
                         state: autosplitter_choice_editor::State::new(
+                            data.timer.clone(),
                             data.auto_splitter.clone(),
-                            use_local_auto_splitter,
+                            data.config.clone(),
                         ),
                     });
                 }
@@ -1370,9 +1369,7 @@ impl AppDelegate<MainState> for WindowManagement {
         if let Some(window) = &data.autosplitter_choice_editor {
             if id == window.id {
                 if !window.state.closed_with_ok {
-                    window
-                        .state
-                        .revert_settings(&mut data.config.borrow_mut(), data.timer.clone());
+                    window.state.revert_settings();
                 }
                 data.autosplitter_choice_editor = None;
                 return;

--- a/src/timer_form.rs
+++ b/src/timer_form.rs
@@ -17,7 +17,9 @@ use livesplit_core::{LayoutEditor, RunEditor, TimerPhase, TimingMethod};
 #[cfg(target_os = "linux")]
 use crate::consts::TIMER_MIN_SIZE;
 #[cfg(feature = "auto-splitting")]
-use crate::{autosplitter_editor, AutoSplitterEditorLens};
+use crate::{config::show_error, auto_splitters, autosplitter_editor, AutoSplitterEditorLens};
+#[cfg(feature = "auto-splitting")]
+use livesplit_core::event::TimerQuery;
 use crate::{
     config::or_show_error,
     consts::{
@@ -107,6 +109,9 @@ const CONTEXT_MENU_EDIT_LAYOUT: Selector = Selector::new("context-menu-edit-layo
 const CONTEXT_MENU_OPEN_LAYOUT: Selector<FileInfo> = Selector::new("context-menu-open-layout");
 const CONTEXT_MENU_SAVE_LAYOUT_AS: Selector<FileInfo> =
     Selector::new("context-menu-save-layout-as");
+#[cfg(feature = "auto-splitting")]
+const CONTEXT_MENU_ACTIVATE_AUTO_SPLITTER: Selector =
+    Selector::new("context-menu-activate-auto-splitter");
 const CONTEXT_MENU_OPEN_AUTO_SPLITTER: Selector<FileInfo> =
     Selector::new("context-menu-open-auto-splitter");
 const CONTEXT_MENU_START_OR_SPLIT: Selector = Selector::new("context-menu-start-or-split");
@@ -323,16 +328,24 @@ impl<T: Widget<MainState>> Widget<MainState> for WithMenu<T> {
                                     )),
                             )
                             .entry(
-                                MenuItem::new("Open Auto-splitter...").command(
-                                    CONTEXT_MENU_SET_INTENT.with(Intent::OPEN_AUTO_SPLITTER),
-                                ),
-                            )
-                            .entry(
                                 #[cfg(feature = "auto-splitting")]
-                                MenuItem::new("Edit Auto-splitter Settings...")
-                                    .command(CONTEXT_MENU_EDIT_AUTOSPLITTER_SETTINGS),
+                                Menu::new("Auto-splitter")
+                                    .entry(
+                                        MenuItem::new("Activate Game Auto-splitter")
+                                            .command(CONTEXT_MENU_ACTIVATE_AUTO_SPLITTER),
+                                    )
+                                    .entry(
+                                        MenuItem::new("Open Local Auto-splitter...").command(
+                                            CONTEXT_MENU_SET_INTENT.with(Intent::OPEN_AUTO_SPLITTER),
+                                        ),
+                                    )
+                                    .entry(
+                                        MenuItem::new("Edit Auto-splitter Settings...")
+                                            .command(CONTEXT_MENU_EDIT_AUTOSPLITTER_SETTINGS),
+                                        
+                                    ),
                                 #[cfg(not(feature = "auto-splitting"))]
-                                MenuItem::new("Auto-splitter settings unavailable").enabled(false),
+                                MenuItem::new("Auto-splitting unavailable").enabled(false),
                             )
                             .separator()
                             .entry(control_menu)
@@ -540,6 +553,26 @@ impl<T: Widget<MainState>> Widget<MainState> for WithMenu<T> {
                         id: window_id,
                         state: server_editor::State::new(data.config.borrow().get_server().clone()),
                     });
+                }
+                #[cfg(feature = "auto-splitting")]
+                if command.is(CONTEXT_MENU_ACTIVATE_AUTO_SPLITTER) {
+                    // TODO
+                    if let Some(auto_splitter_path) = auto_splitters::get_downloader().download_for_game(
+                        auto_splitters::get_list(),
+                        data.timer.get_timer().run().game_name(),
+                        auto_splitters::get_path(),
+                    ) {
+                        let result = data.config.borrow_mut().open_auto_splitter(
+                            #[cfg(feature = "auto-splitting")]
+                            &data.timer,
+                            #[cfg(feature = "auto-splitting")]
+                            &data.auto_splitter,
+                            &auto_splitter_path,
+                        );
+                        or_show_error(result);
+                    } else {
+                        show_error(anyhow::Error::msg("Couldn't download the auto splitter files."));
+                    }
                 }
                 #[cfg(feature = "auto-splitting")]
                 if command.is(CONTEXT_MENU_EDIT_AUTOSPLITTER_SETTINGS) {

--- a/src/timer_form.rs
+++ b/src/timer_form.rs
@@ -86,7 +86,6 @@ impl Intent {
     const NEW_LAYOUT: Self = Self(1 << 9);
     const OPEN_LAYOUT: Self = Self(1 << 10);
     const EXIT: Self = Self(1 << 11);
-    const OPEN_AUTO_SPLITTER: Self = Self(1 << 12);
 
     fn contains(self, other: Self) -> bool {
         (self.0 & other.0) == other.0
@@ -112,11 +111,7 @@ const CONTEXT_MENU_EDIT_LAYOUT: Selector = Selector::new("context-menu-edit-layo
 const CONTEXT_MENU_OPEN_LAYOUT: Selector<FileInfo> = Selector::new("context-menu-open-layout");
 const CONTEXT_MENU_SAVE_LAYOUT_AS: Selector<FileInfo> =
     Selector::new("context-menu-save-layout-as");
-#[cfg(feature = "auto-splitting")]
-const CONTEXT_MENU_ACTIVATE_AUTO_SPLITTER: Selector =
-    Selector::new("context-menu-activate-auto-splitter");
-const CONTEXT_MENU_OPEN_AUTO_SPLITTER: Selector<FileInfo> =
-    Selector::new("context-menu-open-auto-splitter");
+const CONTEXT_MENU_OPEN_AUTO_SPLITTER: Selector = Selector::new("context-menu-open-auto-splitter");
 const CONTEXT_MENU_START_OR_SPLIT: Selector = Selector::new("context-menu-start-or-split");
 const CONTEXT_MENU_UNDO_SPLIT: Selector = Selector::new("context-menu-undo-split");
 const CONTEXT_MENU_SKIP_SPLIT: Selector = Selector::new("context-menu-skip-split");
@@ -339,12 +334,9 @@ impl<T: Widget<MainState>> Widget<MainState> for WithMenu<T> {
                                 #[cfg(feature = "auto-splitting")]
                                 Menu::new("Auto-splitter")
                                     .entry(
-                                        MenuItem::new("Activate Game Auto-splitter")
-                                            .command(CONTEXT_MENU_ACTIVATE_AUTO_SPLITTER),
+                                        MenuItem::new("Open Auto-splitter...")
+                                            .command(CONTEXT_MENU_OPEN_AUTO_SPLITTER),
                                     )
-                                    .entry(MenuItem::new("Open Local Auto-splitter...").command(
-                                        CONTEXT_MENU_SET_INTENT.with(Intent::OPEN_AUTO_SPLITTER),
-                                    ))
                                     .entry(
                                         MenuItem::new("Edit Auto-splitter Settings...")
                                             .command(CONTEXT_MENU_EDIT_AUTOSPLITTER_SETTINGS),
@@ -466,15 +458,6 @@ impl<T: Widget<MainState>> Widget<MainState> for WithMenu<T> {
                         data.layout_data.borrow_mut().is_modified = false;
                     }
                     or_show_error(result);
-                } else if let Some(file_info) = command.get(CONTEXT_MENU_OPEN_AUTO_SPLITTER) {
-                    let result = data.config.borrow_mut().open_auto_splitter(
-                        #[cfg(feature = "auto-splitting")]
-                        &data.timer,
-                        #[cfg(feature = "auto-splitting")]
-                        &data.auto_splitter,
-                        file_info.path(),
-                    );
-                    or_show_error(result);
                 } else if command.is(CONTEXT_MENU_START_OR_SPLIT) {
                     data.timer.write().unwrap().split_or_start().ok();
                 } else if command.is(CONTEXT_MENU_UNDO_SPLIT) {
@@ -558,43 +541,6 @@ impl<T: Widget<MainState>> Widget<MainState> for WithMenu<T> {
                         id: window_id,
                         state: server_editor::State::new(data.config.borrow().get_server().clone()),
                     });
-                }
-                #[cfg(feature = "auto-splitting")]
-                if command.is(CONTEXT_MENU_ACTIVATE_AUTO_SPLITTER) {
-                    // TODO
-                    let timer = data.timer.get_timer();
-                    let game_name = timer.run().game_name();
-                    if let Some(auto_splitter) = auto_splitters::get_list().get_for_game(game_name)
-                    {
-                        if !auto_splitter.is_using_auto_splitting_runtime() {
-                            show_error(anyhow::Error::msg(
-                                "This game's auto splitter is incompatible with LiveSplit One.",
-                            ));
-                        } else if let Some(auto_splitter_path) = auto_splitters::get_downloader()
-                            .download_for_game(
-                                auto_splitters::get_list(),
-                                game_name,
-                                auto_splitters::get_path(),
-                            )
-                        {
-                            let result = data.config.borrow_mut().open_auto_splitter(
-                                #[cfg(feature = "auto-splitting")]
-                                &data.timer,
-                                #[cfg(feature = "auto-splitting")]
-                                &data.auto_splitter,
-                                &auto_splitter_path,
-                            );
-                            or_show_error(result);
-                        } else {
-                            show_error(anyhow::Error::msg(
-                                "Couldn't download the auto splitter files.",
-                            ));
-                        }
-                    } else {
-                        show_error(anyhow::Error::msg(
-                            "No auto splitter available for this game.",
-                        ));
-                    }
                 }
                 #[cfg(feature = "auto-splitting")]
                 if command.is(CONTEXT_MENU_OPEN_AUTO_SPLITTER) {
@@ -804,27 +750,6 @@ impl<T: Widget<MainState>> Widget<MainState> for WithMenu<T> {
                                     },
                                 ])
                                 .accept_command(CONTEXT_MENU_OPEN_LAYOUT),
-                        );
-                        ctx.submit_command(open_dialog);
-                        break;
-                    }
-
-                    if self.intent.contains(Intent::OPEN_AUTO_SPLITTER) {
-                        self.intent = self.intent.without(Intent::OPEN_AUTO_SPLITTER);
-                        let open_dialog = commands::SHOW_OPEN_PANEL.with(
-                            FileDialogOptions::new()
-                                .title("Open Auto-splitter")
-                                .allowed_types(vec![
-                                    FileSpec {
-                                        name: "WASM Auto-splitters",
-                                        extensions: &["wasm"],
-                                    },
-                                    FileSpec {
-                                        name: "All Files",
-                                        extensions: &["*.*"],
-                                    },
-                                ])
-                                .accept_command(CONTEXT_MENU_OPEN_AUTO_SPLITTER),
                         );
                         ctx.submit_command(open_dialog);
                         break;

--- a/src/timer_form.rs
+++ b/src/timer_form.rs
@@ -627,14 +627,9 @@ impl<T: Widget<MainState>> Widget<MainState> for WithMenu<T> {
                     .set_always_on_top(true);
                     let window_id = window.id;
                     ctx.new_window(window);
-                    let use_local_auto_splitter =
-                        data.config.borrow().get_use_local_auto_splitter();
                     data.autosplitter_editor = Some(OpenWindow {
                         id: window_id,
-                        state: autosplitter_editor::State::new(
-                            data.auto_splitter.clone(),
-                            use_local_auto_splitter,
-                        ),
+                        state: autosplitter_editor::State::new(data.auto_splitter.clone()),
                     });
                 }
                 if let Some(intent) = command.get(CONTEXT_MENU_SET_INTENT) {
@@ -1384,9 +1379,7 @@ impl AppDelegate<MainState> for WindowManagement {
         if let Some(window) = &data.autosplitter_editor {
             if id == window.id {
                 if !window.state.closed_with_ok {
-                    window
-                        .state
-                        .revert_settings(&mut data.config.borrow_mut(), data.timer.clone());
+                    window.state.revert_settings();
                 }
                 data.autosplitter_editor = None;
                 return;

--- a/src/timer_form.rs
+++ b/src/timer_form.rs
@@ -17,7 +17,10 @@ use livesplit_core::{LayoutEditor, RunEditor, TimerPhase, TimingMethod};
 #[cfg(target_os = "linux")]
 use crate::consts::TIMER_MIN_SIZE;
 #[cfg(feature = "auto-splitting")]
-use crate::{auto_splitters, autosplitter_choice_editor, autosplitter_editor, config::show_error, AutoSplitterChoiceEditorLens, AutoSplitterEditorLens};
+use crate::{
+    auto_splitters, autosplitter_choice_editor, autosplitter_editor, config::show_error,
+    AutoSplitterChoiceEditorLens, AutoSplitterEditorLens,
+};
 use crate::{
     config::or_show_error,
     consts::{
@@ -596,7 +599,8 @@ impl<T: Widget<MainState>> Widget<MainState> for WithMenu<T> {
                 #[cfg(feature = "auto-splitting")]
                 if command.is(CONTEXT_MENU_OPEN_AUTO_SPLITTER) {
                     let window = WindowDesc::new(
-                        autosplitter_choice_editor::root_widget().lens(AutoSplitterChoiceEditorLens),
+                        autosplitter_choice_editor::root_widget()
+                            .lens(AutoSplitterChoiceEditorLens),
                     )
                     .title("Open Auto-splitter")
                     .with_min_size((550.0, 400.0))


### PR DESCRIPTION
Implementation:
- [ ] A choice between a local auto-splitter stored in the ScriptPath, and an externally-fixed auto-splitter from `LiveSplit.AutoSplitters.xml`
  - [x] Check `is_using_auto_splitting_runtime` before attempting to download
  - [ ] Display it better to the user, with a "use local auto splitter" checkbox similar to OBS LiveSplit One, and put the website link and description somewhere for the user to see
  - [ ] Indicate successful activation to the user as part of this
  - [ ] Support hollowknight-autosplit-wasm even though it's not the Default autosplitter for Hollow Knight

Testing:
- [ ] Saving splits
  - [ ] Saving splits with a local auto-splitter
  - [ ] Saving splits with an externally fixed auto-splitter
- [ ] Changing games with (1) open auto-splitter (2) open splits
- [ ] Changing games with (1) open splits (2) open auto-splitter
- [ ] Transferring splits files between computers with different auto-splitter paths
- [ ] Using legacy_raw_xml to open splits files made with the Default auto-splitter's format, porting them to hollowknight-autosplit-wasm's format
- [ ] Scrolling through large splits files that don't have subsplits in `Curent Group Expanded` subsplit display mode to test that this fixes https://github.com/AlexKnauth/livesplit-one-druid/issues/55

TODO: look into `store_settings` from the perspective of "compatibility with frontends that provide a fixed script externally": in Local auto-splitter mode it should store the ScriptPath, but in Externally-fixed auto-splitter mode, such as when it gets the auto-splitter from `LiveSplit.AutoSplitters.xml`, it should not store the ScriptPath at all, and it should be possible to configure `store_settings` to do that